### PR TITLE
fix: Download build artifact from correct path

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -65,12 +65,13 @@ jobs:
     env:
       PACKAGE_VERSION: ${{ needs.downloadbinaries.outputs.package-version }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: build
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 #4.3.1
         with:
           dotnet-version: "9.0.x"
-      - run: dotnet nuget push Datadog.Serverless/bin/Release/Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      - run: dotnet nuget push Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
   release:
     if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
-          body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/libdatadog/releases/tag/sls-${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
+          body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/serverless-components/releases/tag/sls-${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
           draft: true
           tag_name: "v${{ env.PACKAGE_VERSION }}"
           generate_release_notes: true


### PR DESCRIPTION
### What does this PR do?

* Downloads build artifact from correct path
* Fixes link to serverless-components in release note

### Motivation

Github workflow failing to find build artifact to push to Nuget.

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
