### PR TITLE
fix: copy binary to temp directory and set execute permissions at startup

### DIFF
--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -24,6 +24,9 @@ namespace Datadog.Serverless
         private static readonly ILogger _logger;
         private static string homeDir = Path.DirectorySeparatorChar.ToString();
 
+        [DllImport("libc", SetLastError = true)]
+        private static extern int chmod(string filePath, uint mode);
+
         static CompatibilityLayer()
         {
             var logLevelEnv = Environment.GetEnvironmentVariable("DD_LOG_LEVEL");
@@ -129,6 +132,19 @@ namespace Datadog.Serverless
             }
         }
 
+        private static void SetFilePermissions(string filePath)
+        {
+            if (IsWindows())
+                return;
+
+            int result = chmod(filePath, 0x1E4); // Octal 0744
+            if (result != 0)
+            {
+                int errno = Marshal.GetLastWin32Error();
+                throw new InvalidOperationException($"chmod failed with errno {errno}");
+            }
+        }
+
         public static void Start()
         {
             var environment = GetEnvironment();
@@ -153,7 +169,6 @@ namespace Datadog.Serverless
             }
 
             var binaryPath = GetBinaryPath();
-            _logger.LogDebug("Spawning process from binary at path {binaryPath}", binaryPath);
 
             if (!File.Exists(binaryPath))
             {
@@ -169,9 +184,16 @@ namespace Datadog.Serverless
 
             try
             {
+                string tempDir = Path.Combine(Path.GetTempPath(), "datadog");
+                Directory.CreateDirectory(tempDir);
+                string executableFilePath = Path.Combine(tempDir, Path.GetFileName(binaryPath));
+                File.Copy(binaryPath, executableFilePath, overwrite: true);
+                SetFilePermissions(executableFilePath);
+                _logger.LogDebug("Spawning process from binary at path {binaryPath}", binaryPath);
+
                 var startInfo = new ProcessStartInfo
                 {
-                    FileName = binaryPath,
+                    FileName = executableFilePath,
                     UseShellExecute = false,
                     CreateNoWindow = true
                 };

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -189,7 +189,10 @@ namespace Datadog.Serverless
                 string executableFilePath = Path.Combine(tempDir, Path.GetFileName(binaryPath));
                 File.Copy(binaryPath, executableFilePath, overwrite: true);
                 SetFilePermissions(executableFilePath);
-                _logger.LogDebug("Spawning process from binary at path {binaryPath}", binaryPath);
+                _logger.LogDebug(
+                    "Spawning process from binary at path {executableFilePath}",
+                    executableFilePath
+                );
 
                 var startInfo = new ProcessStartInfo
                 {


### PR DESCRIPTION
### What does this PR do?

Copy `datadog-serverless-compat` binary to a temp directory and set execute permissions at startup.

### Motivation

Depending on the deployment method the execute permissions can be stripped from the binary. This ensures that the binary has execute permissions regardless of the deployment method.

https://datadoghq.atlassian.net/browse/SVLS-6768

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

Deployed package to the environments below with binaries stripped of execute permissions and confirmed that the binary still starts and traces are sent to Datadog. ssh'ed into environments where possible to verify file correctly had execute permissions added (Azure Function PremiumV3 environments).

Tested both a fresh install and an upgrade from the latest version to this development version.

- Azure Function / Linux / PremiumV3 ✅ 
- Azure Function / Linux / Consumption ✅ 
- Azure Function / Linux / Flex ✅ 
- Azure Function / Windows / PremiumV3 ✅ 
- Azure Function / Windows / Consumption ✅ 
