### PR TITLE
build and publish symbols package (`snupkg`) along with `nupkg`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ indent_size = 4
 [{*.yaml,*.yml}]
 indent_style = space
 indent_size = 2
+
+[{*.xml,*.csproj}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,14 +3,16 @@ name: Publish packages on Nuget
 on:
   workflow_dispatch:
     inputs:
-      publish-package:
-        description: "Build or Build and Publish?"
+      publish-github-release:
+        description: "Publish GitHub Release"
         required: true
-        type: choice
-        default: "Build"
-        options:
-          - "Build"
-          - "Build and Publish"
+        type: boolean
+        default: false
+      publish-nuget:
+        description: "Publish to NuGet"
+        required: true
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -62,9 +64,11 @@ jobs:
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: build
-          path: Datadog.Serverless/bin/Release/Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.nupkg
-  publish:
-    if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
+          path: |
+            Datadog.Serverless/bin/Release/Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.nupkg
+            Datadog.Serverless/bin/Release/Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.snupkg
+  publish-nuget:
+    if: ${{ github.event.inputs.publish-nuget == 'true' }}
     needs: [downloadbinaries, build]
     runs-on: ubuntu-latest
     env:
@@ -76,11 +80,13 @@ jobs:
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 #4.3.1
         with:
           dotnet-version: "9.0.x"
-      - run: dotnet nuget push Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-  release:
-    if: ${{ github.event.inputs.publish-package == 'Build and Publish' }}
+      - run: |
+          dotnet nuget push Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+  create-github-release:
+    if: ${{ github.event.inputs.publish-github-release == 'true' }}
     runs-on: ubuntu-latest
-    needs: [downloadbinaries, build, publish]
+    needs: [downloadbinaries, build]
     permissions:
       contents: write
     env:
@@ -89,8 +95,11 @@ jobs:
     steps:
       - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
-          body: "Uses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/serverless-components/releases/tag/${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
+          body: "Install [Datadog.Serverless.Compat](https://www.nuget.org/packages/Datadog.Serverless.Compat/${{ env.PACKAGE_VERSION }}) from NuGet.\n\nUses [${{ env.SERVERLESS_COMPAT_VERSION }}](https://github.com/DataDog/serverless-components/releases/tag/${{ env.SERVERLESS_COMPAT_VERSION }}) of the Serverless Compatibility Layer binary."
           draft: true
           tag_name: "v${{ env.PACKAGE_VERSION }}"
           generate_release_notes: true
           make_latest: true
+          files: |
+            Datadog.Serverless/bin/Release/Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.nupkg
+            Datadog.Serverless/bin/Release/Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.snupkg

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,11 @@ on:
         required: true
         type: boolean
         default: false
+      package-version-override:
+        description: "Package version override (optional, x.y.z)"
+        required: false
+        type: string
+        default: ""
 
 permissions: {}
 
@@ -26,11 +31,15 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - id: package
         run: |
-          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
-            echo "Invalid tag format: $GITHUB_REF, must be in the form vMAJOR.MINOR.PATCH"
-            exit 1
+          if [[ -n "${{ github.event.inputs.package-version-override }}" ]]; then
+            PACKAGE_VERSION="${{ github.event.inputs.package-version-override }}"
+          else
+            if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+              echo "Invalid tag format: $GITHUB_REF, must be in the form vMAJOR.MINOR.PATCH"
+              exit 1
+            fi
+            PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
           fi
-          PACKAGE_VERSION="${GITHUB_REF#refs/tags/v}"
 
           echo "package-version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
       - id: serverlesscompatbinary

--- a/Datadog.Serverless/Datadog.Serverless.Compat.csproj
+++ b/Datadog.Serverless/Datadog.Serverless.Compat.csproj
@@ -17,6 +17,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>Datadog;APM;tracing;instrumentation;serverless</PackageTags>
     <PackageDescription>Datadog Serverless Compat library for .NET.</PackageDescription>
+    <PackageReleaseNotes>See release notes at https://github.com/DataDog/datadog-serverless-compat-dotnet/releases.</PackageReleaseNotes>
     <Copyright>Copyright 2025 Datadog, Inc.</Copyright>
     <Company>Datadog</Company>
     <Authors>Datadog</Authors>

--- a/Datadog.Serverless/Datadog.Serverless.Compat.csproj
+++ b/Datadog.Serverless/Datadog.Serverless.Compat.csproj
@@ -22,6 +22,8 @@
     <Authors>Datadog</Authors>
     <Owners>Datadog</Owners>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 


### PR DESCRIPTION
### What does this PR do?

- nuget package:
  - create and publish `snupkg` symbols file
  - bonus: add link to release notes
- github workflow:
  - update default github release template text to include a link to the nuget package
  - bonus: to help test changes to the github workflow itself:
    - split options to create github release and publish nuget package
    - added optional nuget version override

### Motivation

- Trying to check off the missing nuget pieces (see screenshot, not urgent, but nice to have)
- Adding a link in the nuget package to the github release notes so they're easier to find

<img width="610" height="1024" alt="image" src="https://github.com/user-attachments/assets/d82cfb49-8aa1-4914-a169-e69eac75b1a8" />

### Additional Notes

Nuget docs: https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg
<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

I tested most of the changes by running the workflow manually a few times. We can't test the `snupkg` file until we do another release.
<!-- How was the change validated? Are there automated tests to prevent regressions? -->
