### PR TITLE
remove second `dotnet nuget push` for `snupkg`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,7 +91,6 @@ jobs:
           dotnet-version: "9.0.x"
       - run: |
           dotnet nuget push Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-          dotnet nuget push Datadog.Serverless.Compat.${{ env.PACKAGE_VERSION }}.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
   create-github-release:
     if: ${{ github.event.inputs.publish-github-release == 'true' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?

Remove the second `dotnet nuget push` for the `snupkg` symbols package. The first push command uploads both packages automatically if they are in the same directory.

This behavior is documented in item 3 here: [link](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package)

<img width="1374" height="306" alt="image" src="https://github.com/user-attachments/assets/ad8b4848-19ba-40b9-a89b-db19463a56bc" />


### Motivation

The second push failed when releasing `0.4.0-preview`:
https://github.com/DataDog/datadog-serverless-compat-dotnet/actions/runs/16297439303/job/46022819655

```
> dotnet nuget push Datadog.Serverless.Compat.0.4.0-preview.nupkg ...

1️⃣✅
Pushing Datadog.Serverless.Compat.0.4.0-preview.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
  Created https://www.nuget.org/api/v2/package/ 743ms
Your package was pushed.

2️⃣✅
Pushing Datadog.Serverless.Compat.0.4.0-preview.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
  PUT https://www.nuget.org/api/v2/symbolpackage/
  Created https://www.nuget.org/api/v2/symbolpackage/ 549ms
Your package was pushed.
```

```
> dotnet nuget push Datadog.Serverless.Compat.0.4.0-preview.snupkg ...

3️⃣❌
Pushing Datadog.Serverless.Compat.0.4.0-preview.snupkg to 'https://www.nuget.org/api/v2/symbolpackage'...
  PUT https://www.nuget.org/api/v2/symbolpackage/
  Conflict https://www.nuget.org/api/v2/symbolpackage/ 223ms
To skip already published packages, use the option --skip-duplicate
error: Response status code does not indicate success: 409 (It looks like there is another copy of this symbols package pending validation(s) [...]
```

### Additional Notes

n/a
<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

- I'll publish a new package and keep it unlisted.
- We'll keep an eye on this step when we publish the next version of this nuget package.

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
