### PR TITLE
fix deterministic builds

### DIFF
--- a/Datadog.Serverless/Datadog.Serverless.Compat.csproj
+++ b/Datadog.Serverless/Datadog.Serverless.Compat.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <!-- Use deterministic build in CI -->
-  <PropertyGroup Condition="'$(GITLAB_CI)' == 'true' Or '$(GITHUB_ACTION)' == 'true'">
+  <PropertyGroup Condition="'$(GITLAB_CI)' == 'true' Or '$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
### What does this PR do?

Fix deterministic builds in GitHub Actions by checking `GITHUB_ACTIONS==true`, not `GITHUB_ACTION`. That's a different variable with the name of the GitHub Action, not a Boolean.

### Motivation

<img width="416" height="146" alt="image" src="https://github.com/user-attachments/assets/6e41b1fc-9a75-44b8-841c-655047484573" />

### Additional Notes

- https://docs.github.com/en/actions/reference/variables-reference
- https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
TODO
