### PR TITLE
add a startup hook that starts the agent process

### DIFF
--- a/Datadog.Serverless.sln
+++ b/Datadog.Serverless.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "solution items", "solution 
 		D:\source\datadog\datadog-serverless-compat-dotnet\.gitignore = D:\source\datadog\datadog-serverless-compat-dotnet\.gitignore
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SendEmptyTrace", "SendEmptyTrace\SendEmptyTrace.csproj", "{54FE90FA-2565-4E17-AC0C-84F2E4A02881}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,5 +34,9 @@ Global
 		{C53C00F3-CCC6-47BF-97B6-B658EE928ACC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C53C00F3-CCC6-47BF-97B6-B658EE928ACC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C53C00F3-CCC6-47BF-97B6-B658EE928ACC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54FE90FA-2565-4E17-AC0C-84F2E4A02881}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54FE90FA-2565-4E17-AC0C-84F2E4A02881}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54FE90FA-2565-4E17-AC0C-84F2E4A02881}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54FE90FA-2565-4E17-AC0C-84F2E4A02881}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -19,20 +19,7 @@ public static class CompatibilityLayer
 
     static CompatibilityLayer()
     {
-        var logLevelEnv = Environment.GetEnvironmentVariable("DD_LOG_LEVEL");
-
-        var logLevel = logLevelEnv?.ToUpper() switch
-        {
-            "OFF" or "NONE" => LogLevel.None,
-            "CRITICAL" => LogLevel.Critical,
-            "ERROR" => LogLevel.Error,
-            "WARN" => LogLevel.Warning,
-            "INFO" or "INFORMATION" => LogLevel.Information,
-            "DEBUG" => LogLevel.Debug,
-            "TRACE" => LogLevel.Trace,
-            _ => LogLevel.Information, // default
-        };
-
+        var logLevel = Logging.Logger.GetLogLevelFromEnvironment();
         Logger = new Logger(Console.Out, nameof(CompatibilityLayer), logLevel);
     }
 

--- a/Datadog.Serverless/Logging/Logger.cs
+++ b/Datadog.Serverless/Logging/Logger.cs
@@ -18,6 +18,24 @@ internal sealed class Logger : ILogger
         return level >= _minimumLevel;
     }
 
+    internal static LogLevel GetLogLevelFromEnvironment()
+    {
+        var logLevelEnv = Environment.GetEnvironmentVariable("DD_LOG_LEVEL");
+
+        var logLevel = logLevelEnv?.ToUpper() switch
+        {
+            "OFF" or "NONE" => LogLevel.None,
+            "CRITICAL" => LogLevel.Critical,
+            "ERROR" => LogLevel.Error,
+            "WARN" => LogLevel.Warning,
+            "INFO" or "INFORMATION" => LogLevel.Information,
+            "DEBUG" => LogLevel.Debug,
+            "TRACE" => LogLevel.Trace,
+            _ => LogLevel.Information, // default
+        };
+        return logLevel;
+    }
+
     private void Log(LogLevel level, Exception? exception, string message)
     {
         if (!IsEnabled(level))

--- a/Datadog.Serverless/StartupHook.cs
+++ b/Datadog.Serverless/StartupHook.cs
@@ -1,0 +1,28 @@
+﻿using Datadog.Serverless;
+using Datadog.Serverless.Logging;
+
+// https://github.com/dotnet/runtime/blob/main/docs/design/features/host-startup-hook.md
+
+// ReSharper disable once UnusedType.Global
+// ReSharper disable once CheckNamespace
+internal static class StartupHook
+{
+    // ReSharper disable once UnusedMember.Global
+    public static void Initialize()
+    {
+        Logger? logger = null;
+
+        try
+        {
+            var logLevel = Logger.GetLogLevelFromEnvironment();
+            logger = new Logger(Console.Out, nameof(StartupHook), logLevel);
+            logger.LogInformation("Starting the Datadog Serverless Compatibility Layer.");
+
+            CompatibilityLayer.Start();
+        }
+        catch (Exception ex)
+        {
+            logger?.LogError(ex, "Error starting the Datadog Serverless Compatibility Layer.");
+        }
+    }
+}

--- a/SendEmptyTrace/Program.cs
+++ b/SendEmptyTrace/Program.cs
@@ -1,0 +1,31 @@
+﻿using System.Net.Http.Headers;
+
+while (true)
+{
+    try
+    {
+        // send empty an array in MessagePack format
+        var content = new ByteArrayContent([0x90]);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/msgpack");
+
+        // add these headers to every request
+        using var client = new HttpClient();
+        client.DefaultRequestHeaders.Add("Datadog-Meta-Tracer-Version", "3.25.0.0");
+        client.DefaultRequestHeaders.Add("Datadog-Meta-Lang", ".NET");
+        client.DefaultRequestHeaders.Add("Datadog-Meta-Lang-Interpreter", ".NET"); // ".NET", ".NET Core", or ".NET Framework"
+        client.DefaultRequestHeaders.Add("Datadog-Meta-Lang-Version", Environment.Version.ToString());
+        client.DefaultRequestHeaders.Add("X-Datadog-Trace-Count", "0");
+
+        // try to send the empty trace to the trace agent
+        var response = await client.PostAsync("http://localhost:8126/v0.4/traces", content);
+        response.EnsureSuccessStatusCode();
+
+        Console.WriteLine("Successfully sent empty trace to Datadog agent");
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Failed to send trace: {ex.Message}");
+    }
+
+    await Task.Delay(TimeSpan.FromSeconds(1));
+}

--- a/SendEmptyTrace/SendEmptyTrace.csproj
+++ b/SendEmptyTrace/SendEmptyTrace.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Datadog.Serverless.Compat.Cli</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Datadog.Serverless\Datadog.Serverless.Compat.csproj"/>
+  </ItemGroup>
+  
+</Project>


### PR DESCRIPTION
### What does this PR do?

Add a startup hook that starts the agent process.

Usage: set env var `DOTNET_STARTUP_HOOKS` to the path of `Datadog.Serverless.Compat.dll`

For example, on Windows:
```
DOTNET_STARTUP_HOOKS=C:\home\site\wwwroot\Datadog.Serverless.Compat.dll
```

or on Linux:
```
DOTNET_STARTUP_HOOKS=/home/site/wwwroot/Datadog.Serverless.Compat.dll
```

### Motivation

Allow users to start the trace agent using a startup hook to avoid making code changes.

### Additional Notes

See https://github.com/dotnet/runtime/blob/main/docs/design/features/host-startup-hook.md

Resolves APMSVLS-153

### Describe how to test/QA your changes

Tested locally only (for now) using the `SendEmptyTrace` project also added in this PR.
(Needs better automated tests and e2e tests.)
