### PR TITLE
[SVLS-6337] Don't spawn agent process if DD_AZURE_RESOURCE_GROUP not set for Azure flex consumption functions

### DIFF
--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -95,4 +95,27 @@ public class CompatibilityLayerTests
         // Assert
         Assert.NotEqual("unknown", result);
     }
+
+    [Theory]
+    [InlineData("FlexConsumption", null, true)]
+    [InlineData("FlexConsumption", "test-rg", false)]
+    [InlineData("ElasticPremium", null, false)]
+    [InlineData("ElasticPremium", "test-rg", false)]
+    public void IsAzureFlexWithoutDDAzureResourceGroup_ShouldReturnCorrectValue(string websiteSku, string? ddAzureResourceGroup, bool expected)
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("WEBSITE_SKU", websiteSku);
+        Environment.SetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP", ddAzureResourceGroup);
+
+        // Act
+        var result = CompatibilityLayer.IsAzureFlexWithoutDDAzureResourceGroup();
+
+        // Assert
+        Assert.Equal(expected, result);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("WEBSITE_SKU", null);
+        Environment.SetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP", null);
+    }
 }
+

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -145,6 +145,11 @@ public static class CompatibilityLayer
         return false;
     }
 
+    internal static bool IsAzureFlexWithoutDDAzureResourceGroup()
+    {
+        return Environment.GetEnvironmentVariable("WEBSITE_SKU") == "FlexConsumption" && Environment.GetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP") == null;
+    }
+
     public static void Start()
     {
         // detect values
@@ -177,6 +182,17 @@ public static class CompatibilityLayer
                 $"The Datadog Serverless Compatibility Layer does not support the detected cloud environment: {environment}.");
 
             return;
+        }
+
+        if (environment == CloudEnvironment.AzureFunction)
+        {
+            if (IsAzureFlexWithoutDDAzureResourceGroup())
+            {
+                Logger.LogError(
+                    "Azure function detected on flex consumption plan without DD_AZURE_RESOURCE_GROUP set. Please set the DD_AZURE_RESOURCE_GROUP environment variable to your resource group name in Azure app settings. Shutting down Datadog Serverless Compatibility Layer.");
+
+                return;
+            }
         }
 
         if (!File.Exists(executablePath))

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -184,15 +184,12 @@ public static class CompatibilityLayer
             return;
         }
 
-        if (environment == CloudEnvironment.AzureFunction)
+        if (environment == CloudEnvironment.AzureFunction && IsAzureFlexWithoutDDAzureResourceGroup())
         {
-            if (IsAzureFlexWithoutDDAzureResourceGroup())
-            {
-                Logger.LogError(
-                    "Azure function detected on flex consumption plan without DD_AZURE_RESOURCE_GROUP set. Please set the DD_AZURE_RESOURCE_GROUP environment variable to your resource group name in Azure app settings. Shutting down Datadog Serverless Compatibility Layer.");
-
-                return;
-            }
+            Logger.LogError(
+                "Azure function detected on flex consumption plan without DD_AZURE_RESOURCE_GROUP set. Please set the DD_AZURE_RESOURCE_GROUP environment variable to your resource group name in Azure app settings. Shutting down Datadog Serverless Compatibility Layer.");
+            
+            return;
         }
 
         if (!File.Exists(executablePath))


### PR DESCRIPTION
### What does this PR do?
Adds a check to see if we are in an Azure function that is on the flex consumption plan and doesn't have the `DD_AZURE_RESOURCE_GROUP` env var set. If so, return before the agent process can be spawned.
  - We updated the libdatadog [Azure metadata detection logic](https://github.com/DataDog/libdatadog/pull/1241) to check for the resource group similarly, as well as [serverless-components/datadog-trace-agent](https://github.com/DataDog/serverless-components/pull/39) to shut down the trace agent if the resource group can't be determined

### Motivation
- Currently the `aas.resource.group` span attribute for functions on flex consumption plans is set incorrectly in Datadog - they're all set to "flex"
  - This is important to fix because `aas.resource.id` is built using `aas.resource.group`, and the resource id is used in billing, which needs to be accurate
  - We had to figure out what to do if a customer who is using Datadog to monitor their Azure function on a flex consumption plan doesn't set the `DD_AZURE_RESOURCE_GROUP` env var. Rather than handling that in `libdatadog`, we decided to do it at a higher level in the trace agent to inform the customer of the error while shutting down the trace agent gracefully and preventing any traces from being sent to Datadog, as well as adding this in the serverless-compat layers to have defense in depth

[Jira Ticket](https://datadoghq.atlassian.net/browse/SVLS-6337?atlOrigin=eyJpIjoiNzhhNTkwOWFmODFhNGZjZmJhZDc1OGE2ZjJkOTg0NjYiLCJwIjoiaiJ9)

### Describe how to test/QA your changes
1. Clone [serverless-components](https://github.com/DataDog/serverless-components/tree/main) and update the commit hash in [datadog-trace-agent/Cargo.toml
](https://github.com/DataDog/serverless-components/blob/main/crates/datadog-trace-agent/Cargo.toml) everywhere that `libdatadog` is used to the most recent commit hash of the PR in [libdatadog](https://github.com/DataDog/libdatadog/pull/1241) (currently `d1b35ef21fff3c4588073504905081c8923bbc4b`)
2. Follow the instructions in the [Serverless Compatability Layer docs](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Compatibility+Layer) to build the Rust binary
3. Deploy an Azure function on flex consumption plan using [the terraform tool](https://github.com/DataDog/serverless-init-self-monitoring/tree/main/old-self-monitoring/azure/functions), setting `use_serverless_compat_local_path` to true and making sure the built binary is in your `python` folder
4. Hit an endpoint in your function or wait a minute for the invoker to invoke your function and check the Datadog traces for your function. Without the `DD_AZURE_RESOURCE_GROUP` env var, you should see no traces
5. Go to Settings > Environment Variables in the Azure Portal for your function and add `DD_AZURE_RESOURCE_GROUP` as an environment variable with your resource group. Repeat step 4, you should see the correct resource group in the `resource.group` span attribute!
<img width="1736" height="1318" alt="image" src="https://github.com/user-attachments/assets/eb5227a7-004f-4f76-b481-20604dea6178" />
