### PR TITLE
chore: update codeowners to use @DataDog/serverless-azure-and-gcp team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @DataDog/serverless-azure-gcp @DataDog/apm-serverless
+* @DataDog/serverless-azure-and-gcp @DataDog/apm-serverless


### PR DESCRIPTION
### What does this PR do?

Update codeowners to use `@DataDog/serverless-azure-and-gcp team`

### Motivation

`@DataDog/serverless-azure-and-gcp team` is automatically maintained.

https://datadoghq.atlassian.net/browse/SVLS-8181

### Additional Notes

<!-- Any other relevant context that would be helpful. -->

### Describe how to test/QA your changes

<!-- How was the change validated? Are there automated tests to prevent regressions? -->
