### PR TITLE
Compat: Add Multi-Azure Function Unique Named Pipe Configuration

### DIFF
--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -3,24 +3,25 @@ using Xunit;
 
 namespace Datadog.Serverless.Compat.Tests;
 
+/// <summary>
+/// Tests that modify environment variables must not run in parallel to avoid test pollution.
+/// </summary>
+[Collection(nameof(EnvironmentVariablesTestCollection))]
 public class CompatibilityLayerTests
 {
     [Fact]
     public void GetEnvironment_ShouldReturnAzureFunction_WhenAzureEnvironmentVariablesAreSet()
     {
         // Arrange
-        Environment.SetEnvironmentVariable("FUNCTIONS_EXTENSION_VERSION", "some_version");
-        Environment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "some_runtime");
+        using var _ = new EnvironmentVariableScope(
+            ("FUNCTIONS_EXTENSION_VERSION", "some_version"),
+            ("FUNCTIONS_WORKER_RUNTIME", "some_runtime"));
 
         // Act
         var result = CompatibilityLayer.GetEnvironment();
 
         // Assert
         Assert.Equal(CloudEnvironment.AzureFunction, result);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("FUNCTIONS_EXTENSION_VERSION", null);
-        Environment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", null);
     }
 
     [Fact]
@@ -104,18 +105,15 @@ public class CompatibilityLayerTests
     public void IsAzureFlexWithoutDDAzureResourceGroup_ShouldReturnCorrectValue(string websiteSku, string? ddAzureResourceGroup, bool expected)
     {
         // Arrange
-        Environment.SetEnvironmentVariable("WEBSITE_SKU", websiteSku);
-        Environment.SetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP", ddAzureResourceGroup);
+        using var _ = new EnvironmentVariableScope(
+            ("WEBSITE_SKU", websiteSku),
+            ("DD_AZURE_RESOURCE_GROUP", ddAzureResourceGroup));
 
         // Act
         var result = CompatibilityLayer.IsAzureFlexWithoutDDAzureResourceGroup();
 
         // Assert
         Assert.Equal(expected, result);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("WEBSITE_SKU", null);
-        Environment.SetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP", null);
     }
 
     [Theory]
@@ -124,7 +122,7 @@ public class CompatibilityLayerTests
     public void CalculateTracePipeName_ShouldGenerateUniqueName(string? traceWindowsPipeName, string expectedPrefix)
     {
         // Arrange
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", traceWindowsPipeName);
+        using var _ = new EnvironmentVariableScope(("DD_TRACE_WINDOWS_PIPE_NAME", traceWindowsPipeName));
 
         // Act
         var pipeName1 = CompatibilityLayer.CalculateTracePipeName();
@@ -142,9 +140,6 @@ public class CompatibilityLayerTests
         // Format should be: {base}_{guid}
         // GUID is 32 characters (N format)
         Assert.Equal(expectedPrefix.Length + 32, pipeName1.Length);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
     }
 
     [Theory]
@@ -153,7 +148,7 @@ public class CompatibilityLayerTests
     public void CalculateDogStatsDPipeName_ShouldGenerateUniqueName(string? dogstatsdWindowsPipeName, string expectedPrefix)
     {
         // Arrange
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", dogstatsdWindowsPipeName);
+        using var _ = new EnvironmentVariableScope(("DD_DOGSTATSD_WINDOWS_PIPE_NAME", dogstatsdWindowsPipeName));
 
         // Act
         var pipeName1 = CompatibilityLayer.CalculateDogStatsDPipeName();
@@ -170,9 +165,6 @@ public class CompatibilityLayerTests
 
         // Format should be: {base}_{guid}
         Assert.Equal(expectedPrefix.Length + 32, pipeName1.Length);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
     }
 
     [Fact]
@@ -180,7 +172,7 @@ public class CompatibilityLayerTests
     {
         // Arrange
         var longPipeName = new string('a', 300); // Exceeds max base length of 214
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", longPipeName);
+        using var _ = new EnvironmentVariableScope(("DD_TRACE_WINDOWS_PIPE_NAME", longPipeName));
 
         // Act
         var pipeName = CompatibilityLayer.CalculateTracePipeName();
@@ -189,9 +181,6 @@ public class CompatibilityLayerTests
         Assert.NotNull(pipeName);
         // Pipe name should be 247 chars: 214 (base) + 1 (underscore) + 32 (GUID)
         Assert.Equal(247, pipeName.Length);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
     }
 
     [Fact]
@@ -199,7 +188,7 @@ public class CompatibilityLayerTests
     {
         // Arrange
         var longPipeName = new string('a', 300); // Exceeds max base length of 214
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", longPipeName);
+        using var _ = new EnvironmentVariableScope(("DD_DOGSTATSD_WINDOWS_PIPE_NAME", longPipeName));
 
         // Act
         var pipeName = CompatibilityLayer.CalculateDogStatsDPipeName();
@@ -208,9 +197,6 @@ public class CompatibilityLayerTests
         Assert.NotNull(pipeName);
         // Pipe name should be 247 chars: 214 (base) + 1 (underscore) + 32 (GUID)
         Assert.Equal(247, pipeName.Length);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
     }
 
     [Theory]
@@ -223,11 +209,11 @@ public class CompatibilityLayerTests
         string expectedDogstatsdPrefix)
     {
         // Arrange
+        using var _ = new EnvironmentVariableScope(
+            ("DD_TRACE_WINDOWS_PIPE_NAME", traceWindowsPipeName),
+            ("DD_DOGSTATSD_WINDOWS_PIPE_NAME", dogstatsdWindowsPipeName));
         var startInfo = new System.Diagnostics.ProcessStartInfo();
         const OS os = OS.Windows;
-
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", traceWindowsPipeName);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", dogstatsdWindowsPipeName);
 
         // Act
         CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
@@ -240,10 +226,6 @@ public class CompatibilityLayerTests
         Assert.NotNull(resultDogstatsdPipeName);
         Assert.StartsWith(expectedTracePrefix, resultTracePipeName);
         Assert.StartsWith(expectedDogstatsdPrefix, resultDogstatsdPipeName);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
     }
 
     [Fact]
@@ -260,5 +242,40 @@ public class CompatibilityLayerTests
         Assert.False(startInfo.EnvironmentVariables.ContainsKey("DD_TRACE_WINDOWS_PIPE_NAME"));
         Assert.False(startInfo.EnvironmentVariables.ContainsKey("DD_DOGSTATSD_WINDOWS_PIPE_NAME"));
     }
+}
+
+/// <summary>
+/// Helper class to temporarily set environment variables and automatically restore them on disposal.
+/// Ensures proper cleanup even if tests fail, preventing test pollution.
+/// </summary>
+internal sealed class EnvironmentVariableScope : IDisposable
+{
+    private readonly Dictionary<string, string?> _originalValues = new();
+
+    public EnvironmentVariableScope(params (string name, string? value)[] variables)
+    {
+        foreach (var (name, value) in variables)
+        {
+            _originalValues[name] = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var (name, originalValue) in _originalValues)
+        {
+            Environment.SetEnvironmentVariable(name, originalValue);
+        }
+    }
+}
+
+/// <summary>
+/// Used to indicate tests that modify environment variables.
+/// Tests in this collection will not run in parallel to prevent cross-test pollution.
+/// </summary>
+[CollectionDefinition(nameof(EnvironmentVariablesTestCollection), DisableParallelization = true)]
+public class EnvironmentVariablesTestCollection
+{
 }
 

--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -236,12 +236,12 @@ public class CompatibilityLayerTests
     }
 
     [Fact]
-    public void ConfigureNamedPipes_ShouldTruncateLongPipeNames()
+    public void ConfigureNamedPipes_ShouldTruncateBaseName_WhenTooLong()
     {
         // Arrange
         var startInfo = new System.Diagnostics.ProcessStartInfo();
         const OS os = OS.Windows;
-        var longPipeName = new string('a', 300); // 300 characters, exceeds limit
+        var longPipeName = new string('a', 300); // 300 characters, exceeds max base length of 223
 
         Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", longPipeName);
         Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", longPipeName);
@@ -255,50 +255,14 @@ public class CompatibilityLayerTests
 
         Assert.NotNull(tracePipeName);
         Assert.NotNull(dogstatsdPipeName);
-        Assert.True(tracePipeName.Length <= 256);
-        Assert.True(dogstatsdPipeName.Length <= 256);
+        Assert.Equal(256, tracePipeName.Length);
+        Assert.Equal(256, dogstatsdPipeName.Length);
 
         // Cleanup
         Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
         Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
         Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
         Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
-    }
-
-    [Fact]
-    public void ConfigureNamedPipes_ShouldGenerateUniquePipeNames_OnMultipleCalls()
-    {
-        // Arrange
-        var startInfo1 = new System.Diagnostics.ProcessStartInfo();
-        var startInfo2 = new System.Diagnostics.ProcessStartInfo();
-        const OS os = OS.Windows;
-
-        // Clear any existing pipe name configurations
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
-
-        // Act
-        CompatibilityLayer.ConfigureNamedPipes(startInfo1, os);
-        var tracePipeName1 = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
-        var dogstatsdPipeName1 = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
-
-        // Clear environment variables to simulate a new function instance
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
-
-        CompatibilityLayer.ConfigureNamedPipes(startInfo2, os);
-        var tracePipeName2 = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
-        var dogstatsdPipeName2 = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
-
-        // Assert
-        Assert.NotEqual(tracePipeName1, tracePipeName2);
-        Assert.NotEqual(dogstatsdPipeName1, dogstatsdPipeName2);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
     }
 }
 

--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -118,36 +118,46 @@ public class CompatibilityLayerTests
         Environment.SetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP", null);
     }
 
-    [Fact]
-    public void ConfigureNamedPipes_ShouldGenerateUniqueNames_OnWindows()
+    [Theory]
+    [InlineData(null, null, null, null, "dd_trace_", "dd_dogstatsd_")] // Default names
+    [InlineData("custom_trace", "custom_dogstatsd", null, null, "custom_trace_", "custom_dogstatsd_")] // WINDOWS_PIPE_NAME set
+    [InlineData(null, null, "other_trace", "other_dogstatsd", "other_trace_", "other_dogstatsd_")] // PIPE_NAME set
+    public void ConfigureNamedPipes_ShouldConfigureCorrectly_OnWindows(
+        string? traceWindowsPipeName,
+        string? dogstatsdWindowsPipeName,
+        string? tracePipeName,
+        string? dogstatsdPipeName,
+        string expectedTracePrefix,
+        string expectedDogstatsdPrefix)
     {
         // Arrange
         var startInfo = new System.Diagnostics.ProcessStartInfo();
         const OS os = OS.Windows;
 
-        // Clear any existing pipe name configurations
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", traceWindowsPipeName);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", dogstatsdWindowsPipeName);
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", tracePipeName);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", dogstatsdPipeName);
 
         // Act
         CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
 
         // Assert
-        var tracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
-        var dogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+        var resultTracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
+        var resultDogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
 
-        Assert.NotNull(tracePipeName);
-        Assert.NotNull(dogstatsdPipeName);
-        Assert.StartsWith("dd_trace_", tracePipeName);
-        Assert.StartsWith("dd_dogstatsd_", dogstatsdPipeName);
-        Assert.Equal(tracePipeName, startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"]);
-        Assert.Equal(dogstatsdPipeName, startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
+        Assert.NotNull(resultTracePipeName);
+        Assert.NotNull(resultDogstatsdPipeName);
+        Assert.StartsWith(expectedTracePrefix, resultTracePipeName);
+        Assert.StartsWith(expectedDogstatsdPrefix, resultDogstatsdPipeName);
+        Assert.Equal(resultTracePipeName, startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"]);
+        Assert.Equal(resultDogstatsdPipeName, startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
 
         // Cleanup
         Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
         Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
     }
 
     [Fact]
@@ -170,78 +180,12 @@ public class CompatibilityLayerTests
     }
 
     [Fact]
-    public void ConfigureNamedPipes_ShouldAppendGuid_WhenWindowsPipeNameSet()
-    {
-        // Arrange
-        var startInfo = new System.Diagnostics.ProcessStartInfo();
-        const OS os = OS.Windows;
-        const string customTracePipeName = "custom_trace_pipe";
-        const string customDogstatsdPipeName = "custom_dogstatsd_pipe";
-
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", customTracePipeName);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", customDogstatsdPipeName);
-
-        // Act
-        CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
-
-        // Assert
-        var tracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
-        var dogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
-
-        Assert.NotNull(tracePipeName);
-        Assert.NotNull(dogstatsdPipeName);
-        Assert.StartsWith(customTracePipeName + "_", tracePipeName);
-        Assert.StartsWith(customDogstatsdPipeName + "_", dogstatsdPipeName);
-        Assert.Equal(tracePipeName, startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"]);
-        Assert.Equal(dogstatsdPipeName, startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
-    }
-
-    [Fact]
-    public void ConfigureNamedPipes_ShouldAppendGuid_WhenPipeNameSet()
-    {
-        // Arrange
-        var startInfo = new System.Diagnostics.ProcessStartInfo();
-        const OS os = OS.Windows;
-        const string customTracePipeName = "custom_trace_pipe";
-        const string customDogstatsdPipeName = "custom_dogstatsd_pipe";
-
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", customTracePipeName);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", customDogstatsdPipeName);
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
-
-        // Act
-        CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
-
-        // Assert
-        var tracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
-        var dogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
-
-        Assert.NotNull(tracePipeName);
-        Assert.NotNull(dogstatsdPipeName);
-        Assert.StartsWith(customTracePipeName + "_", tracePipeName);
-        Assert.StartsWith(customDogstatsdPipeName + "_", dogstatsdPipeName);
-        Assert.Equal(tracePipeName, startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"]);
-        Assert.Equal(dogstatsdPipeName, startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
-    }
-
-    [Fact]
     public void ConfigureNamedPipes_ShouldTruncateBaseName_WhenTooLong()
     {
         // Arrange
         var startInfo = new System.Diagnostics.ProcessStartInfo();
         const OS os = OS.Windows;
-        var longPipeName = new string('a', 300); // 300 characters, exceeds max base length of 223
+        var longPipeName = new string('a', 300); // 300 characters, exceeds max base length of 214
 
         Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", longPipeName);
         Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", longPipeName);
@@ -255,8 +199,11 @@ public class CompatibilityLayerTests
 
         Assert.NotNull(tracePipeName);
         Assert.NotNull(dogstatsdPipeName);
-        Assert.Equal(256, tracePipeName.Length);
-        Assert.Equal(256, dogstatsdPipeName.Length);
+
+        // Pipe name should be 247 chars: 214 (base) + 1 (underscore) + 32 (GUID)
+        // Full path \\.\pipe\{name} would be 256 chars total
+        Assert.Equal(247, tracePipeName.Length);
+        Assert.Equal(247, dogstatsdPipeName.Length);
 
         // Cleanup
         Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);

--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -245,9 +245,11 @@ public class CompatibilityLayerTests
         Assert.StartsWith("dd_trace_", resultTracePipeName);
         Assert.StartsWith("dd_dogstatsd_", resultDogstatsdPipeName);
 
-        // Assert — current process env vars match (for in-process consumers like DogStatsD client)
-        Assert.Equal(resultTracePipeName, Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME"));
+        // DD_DOGSTATSD_PIPE_NAME is set for the in-process DogStatsD client SDK.
+        // DD_TRACE_PIPE_NAME is intentionally NOT set — the tracer reads its own ExporterSettings,
+        // and the mini-agent gets the name via DD_APM_WINDOWS_PIPE_NAME in the spawned process env.
         Assert.Equal(resultDogstatsdPipeName, Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME"));
+        Assert.Null(Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME"));
     }
 
     [Fact]
@@ -268,9 +270,9 @@ public class CompatibilityLayerTests
         Assert.Equal("custom_trace", startInfo.EnvironmentVariables["DD_APM_WINDOWS_PIPE_NAME"]);
         Assert.Equal("custom_dogstatsd", startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
 
-        // Assert — current process env vars match
-        Assert.Equal("custom_trace", Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME"));
+        // Assert — only DogStatsD is set in the current process (for lazy client init)
         Assert.Equal("custom_dogstatsd", Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME"));
+        Assert.Null(Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME"));
     }
 
     [Fact]
@@ -291,6 +293,53 @@ public class CompatibilityLayerTests
         Assert.False(startInfo.EnvironmentVariables.ContainsKey("DD_DOGSTATSD_WINDOWS_PIPE_NAME"));
         Assert.Null(Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME"));
         Assert.Null(Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Instrumentation contract tests
+    //
+    // The dd-trace-dotnet tracer ships calltarget definitions that target
+    // CalculateTracePipeName and CalculateDogStatsDPipeName by exact symbol.
+    // Renaming either method, changing its parameters, or moving it to a
+    // different type/assembly silently disables the integration — the native
+    // profiler skips unrecognised symbols without throwing.
+    //
+    // These tests fail at compile time (via nameof) on a rename and at runtime
+    // on a signature or accessibility change, making the contract explicit.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void InstrumentationContract_CalculateTracePipeName_SignatureIsStable()
+    {
+        var method = typeof(CompatibilityLayer).GetMethod(
+            nameof(CompatibilityLayer.CalculateTracePipeName),
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+
+        Assert.NotNull(method);
+        Assert.Equal(typeof(string), method!.ReturnType);
+        Assert.Empty(method.GetParameters());
+
+        // Assembly name and type name are part of the calltarget contract
+        Assert.Equal("Datadog.Serverless.Compat", typeof(CompatibilityLayer).Assembly.GetName().Name);
+        Assert.Equal("Datadog.Serverless.CompatibilityLayer", typeof(CompatibilityLayer).FullName);
+    }
+
+    [Fact]
+    public void InstrumentationContract_CalculateDogStatsDPipeName_SignatureIsStable()
+    {
+        var method = typeof(CompatibilityLayer).GetMethod(
+            nameof(CompatibilityLayer.CalculateDogStatsDPipeName),
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
+            binder: null,
+            types: Type.EmptyTypes,
+            modifiers: null);
+
+        Assert.NotNull(method);
+        Assert.Equal(typeof(string), method!.ReturnType);
+        Assert.Empty(method.GetParameters());
     }
 }
 

--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -263,9 +263,9 @@ internal sealed class EnvironmentVariableScope : IDisposable
 
     public void Dispose()
     {
-        foreach (var (name, originalValue) in _originalValues)
+        foreach (var kvp in _originalValues)
         {
-            Environment.SetEnvironmentVariable(name, originalValue);
+            Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
         }
     }
 }

--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -119,14 +119,106 @@ public class CompatibilityLayerTests
     }
 
     [Theory]
-    [InlineData(null, null, null, null, "dd_trace_", "dd_dogstatsd_")] // Default names
-    [InlineData("custom_trace", "custom_dogstatsd", null, null, "custom_trace_", "custom_dogstatsd_")] // WINDOWS_PIPE_NAME set
-    [InlineData(null, null, "other_trace", "other_dogstatsd", "other_trace_", "other_dogstatsd_")] // PIPE_NAME set
-    public void ConfigureNamedPipes_ShouldConfigureCorrectly_OnWindows(
+    [InlineData(null, "dd_trace_")] // Default name
+    [InlineData("custom_trace", "custom_trace_")] // WINDOWS_PIPE_NAME set
+    public void CalculateTracePipeName_ShouldGenerateUniqueName(string? traceWindowsPipeName, string expectedPrefix)
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", traceWindowsPipeName);
+
+        // Act
+        var pipeName1 = CompatibilityLayer.CalculateTracePipeName();
+        var pipeName2 = CompatibilityLayer.CalculateTracePipeName();
+
+        // Assert
+        Assert.NotNull(pipeName1);
+        Assert.NotNull(pipeName2);
+        Assert.StartsWith(expectedPrefix, pipeName1);
+        Assert.StartsWith(expectedPrefix, pipeName2);
+
+        // Each call should generate a unique GUID
+        Assert.NotEqual(pipeName1, pipeName2);
+
+        // Format should be: {base}_{guid}
+        // GUID is 32 characters (N format)
+        Assert.Equal(expectedPrefix.Length + 32, pipeName1.Length);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
+    }
+
+    [Theory]
+    [InlineData(null, "dd_dogstatsd_")] // Default name
+    [InlineData("custom_dogstatsd", "custom_dogstatsd_")] // WINDOWS_PIPE_NAME set
+    public void CalculateDogStatsDPipeName_ShouldGenerateUniqueName(string? dogstatsdWindowsPipeName, string expectedPrefix)
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", dogstatsdWindowsPipeName);
+
+        // Act
+        var pipeName1 = CompatibilityLayer.CalculateDogStatsDPipeName();
+        var pipeName2 = CompatibilityLayer.CalculateDogStatsDPipeName();
+
+        // Assert
+        Assert.NotNull(pipeName1);
+        Assert.NotNull(pipeName2);
+        Assert.StartsWith(expectedPrefix, pipeName1);
+        Assert.StartsWith(expectedPrefix, pipeName2);
+
+        // Each call should generate a unique GUID
+        Assert.NotEqual(pipeName1, pipeName2);
+
+        // Format should be: {base}_{guid}
+        Assert.Equal(expectedPrefix.Length + 32, pipeName1.Length);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
+    }
+
+    [Fact]
+    public void CalculateTracePipeName_ShouldTruncateBaseName_WhenTooLong()
+    {
+        // Arrange
+        var longPipeName = new string('a', 300); // Exceeds max base length of 214
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", longPipeName);
+
+        // Act
+        var pipeName = CompatibilityLayer.CalculateTracePipeName();
+
+        // Assert
+        Assert.NotNull(pipeName);
+        // Pipe name should be 247 chars: 214 (base) + 1 (underscore) + 32 (GUID)
+        Assert.Equal(247, pipeName.Length);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
+    }
+
+    [Fact]
+    public void CalculateDogStatsDPipeName_ShouldTruncateBaseName_WhenTooLong()
+    {
+        // Arrange
+        var longPipeName = new string('a', 300); // Exceeds max base length of 214
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", longPipeName);
+
+        // Act
+        var pipeName = CompatibilityLayer.CalculateDogStatsDPipeName();
+
+        // Assert
+        Assert.NotNull(pipeName);
+        // Pipe name should be 247 chars: 214 (base) + 1 (underscore) + 32 (GUID)
+        Assert.Equal(247, pipeName.Length);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
+    }
+
+    [Theory]
+    [InlineData(null, null, "dd_trace_", "dd_dogstatsd_")] // Default names
+    [InlineData("custom_trace", "custom_dogstatsd", "custom_trace_", "custom_dogstatsd_")] // WINDOWS_PIPE_NAME set
+    public void ConfigureNamedPipes_ShouldPassPipeNamesToStartInfo_OnWindows(
         string? traceWindowsPipeName,
         string? dogstatsdWindowsPipeName,
-        string? tracePipeName,
-        string? dogstatsdPipeName,
         string expectedTracePrefix,
         string expectedDogstatsdPrefix)
     {
@@ -136,26 +228,20 @@ public class CompatibilityLayerTests
 
         Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", traceWindowsPipeName);
         Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", dogstatsdWindowsPipeName);
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", tracePipeName);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", dogstatsdPipeName);
 
         // Act
         CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
 
         // Assert
-        var resultTracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
-        var resultDogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+        var resultTracePipeName = startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"];
+        var resultDogstatsdPipeName = startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"];
 
         Assert.NotNull(resultTracePipeName);
         Assert.NotNull(resultDogstatsdPipeName);
         Assert.StartsWith(expectedTracePrefix, resultTracePipeName);
         Assert.StartsWith(expectedDogstatsdPrefix, resultDogstatsdPipeName);
-        Assert.Equal(resultTracePipeName, startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"]);
-        Assert.Equal(resultDogstatsdPipeName, startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
 
         // Cleanup
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
         Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
         Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
     }
@@ -167,49 +253,12 @@ public class CompatibilityLayerTests
         var startInfo = new System.Diagnostics.ProcessStartInfo();
         const OS os = OS.Linux;
 
-        // Clear any existing pipe name configurations
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
-
         // Act
         CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
 
         // Assert
         Assert.False(startInfo.EnvironmentVariables.ContainsKey("DD_TRACE_WINDOWS_PIPE_NAME"));
         Assert.False(startInfo.EnvironmentVariables.ContainsKey("DD_DOGSTATSD_WINDOWS_PIPE_NAME"));
-    }
-
-    [Fact]
-    public void ConfigureNamedPipes_ShouldTruncateBaseName_WhenTooLong()
-    {
-        // Arrange
-        var startInfo = new System.Diagnostics.ProcessStartInfo();
-        const OS os = OS.Windows;
-        var longPipeName = new string('a', 300); // 300 characters, exceeds max base length of 214
-
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", longPipeName);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", longPipeName);
-
-        // Act
-        CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
-
-        // Assert
-        var tracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
-        var dogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
-
-        Assert.NotNull(tracePipeName);
-        Assert.NotNull(dogstatsdPipeName);
-
-        // Pipe name should be 247 chars: 214 (base) + 1 (underscore) + 32 (GUID)
-        // Full path \\.\pipe\{name} would be 256 chars total
-        Assert.Equal(247, tracePipeName.Length);
-        Assert.Equal(247, dogstatsdPipeName.Length);
-
-        // Cleanup
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
     }
 }
 

--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -236,7 +236,7 @@ public class CompatibilityLayerTests
         // Act
         CompatibilityLayer.ConfigureNamedPipes(startInfo, OS.Windows);
 
-        // Assert
+        // Assert — spawned process env vars
         var resultTracePipeName = startInfo.EnvironmentVariables["DD_APM_WINDOWS_PIPE_NAME"];
         var resultDogstatsdPipeName = startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"];
 
@@ -244,6 +244,10 @@ public class CompatibilityLayerTests
         Assert.NotNull(resultDogstatsdPipeName);
         Assert.StartsWith("dd_trace_", resultTracePipeName);
         Assert.StartsWith("dd_dogstatsd_", resultDogstatsdPipeName);
+
+        // Assert — current process env vars match (for in-process consumers like DogStatsD client)
+        Assert.Equal(resultTracePipeName, Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME"));
+        Assert.Equal(resultDogstatsdPipeName, Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME"));
     }
 
     [Fact]
@@ -260,15 +264,22 @@ public class CompatibilityLayerTests
         // Act
         CompatibilityLayer.ConfigureNamedPipes(startInfo, OS.Windows);
 
-        // Assert
+        // Assert — spawned process env vars
         Assert.Equal("custom_trace", startInfo.EnvironmentVariables["DD_APM_WINDOWS_PIPE_NAME"]);
         Assert.Equal("custom_dogstatsd", startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
+
+        // Assert — current process env vars match
+        Assert.Equal("custom_trace", Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME"));
+        Assert.Equal("custom_dogstatsd", Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME"));
     }
 
     [Fact]
     public void ConfigureNamedPipes_ShouldNotConfigurePipes_OnLinux()
     {
         // Arrange
+        using var _ = new EnvironmentVariableScope(
+            ("DD_TRACE_PIPE_NAME", null),
+            ("DD_DOGSTATSD_PIPE_NAME", null));
         var startInfo = new System.Diagnostics.ProcessStartInfo();
         const OS os = OS.Linux;
 
@@ -278,6 +289,8 @@ public class CompatibilityLayerTests
         // Assert
         Assert.False(startInfo.EnvironmentVariables.ContainsKey("DD_TRACE_WINDOWS_PIPE_NAME"));
         Assert.False(startInfo.EnvironmentVariables.ContainsKey("DD_DOGSTATSD_WINDOWS_PIPE_NAME"));
+        Assert.Null(Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME"));
+        Assert.Null(Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME"));
     }
 }
 

--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -117,5 +117,188 @@ public class CompatibilityLayerTests
         Environment.SetEnvironmentVariable("WEBSITE_SKU", null);
         Environment.SetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP", null);
     }
+
+    [Fact]
+    public void ConfigureNamedPipes_ShouldGenerateUniqueNames_OnWindows()
+    {
+        // Arrange
+        var startInfo = new System.Diagnostics.ProcessStartInfo();
+        const OS os = OS.Windows;
+
+        // Clear any existing pipe name configurations
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
+
+        // Act
+        CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
+
+        // Assert
+        var tracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
+        var dogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+
+        Assert.NotNull(tracePipeName);
+        Assert.NotNull(dogstatsdPipeName);
+        Assert.StartsWith("dd_trace_", tracePipeName);
+        Assert.StartsWith("dd_dogstatsd_", dogstatsdPipeName);
+        Assert.Equal(tracePipeName, startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"]);
+        Assert.Equal(dogstatsdPipeName, startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+    }
+
+    [Fact]
+    public void ConfigureNamedPipes_ShouldNotConfigurePipes_OnLinux()
+    {
+        // Arrange
+        var startInfo = new System.Diagnostics.ProcessStartInfo();
+        const OS os = OS.Linux;
+
+        // Clear any existing pipe name configurations
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+
+        // Act
+        CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
+
+        // Assert
+        Assert.False(startInfo.EnvironmentVariables.ContainsKey("DD_TRACE_WINDOWS_PIPE_NAME"));
+        Assert.False(startInfo.EnvironmentVariables.ContainsKey("DD_DOGSTATSD_WINDOWS_PIPE_NAME"));
+    }
+
+    [Fact]
+    public void ConfigureNamedPipes_ShouldAppendGuid_WhenWindowsPipeNameSet()
+    {
+        // Arrange
+        var startInfo = new System.Diagnostics.ProcessStartInfo();
+        const OS os = OS.Windows;
+        const string customTracePipeName = "custom_trace_pipe";
+        const string customDogstatsdPipeName = "custom_dogstatsd_pipe";
+
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", customTracePipeName);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", customDogstatsdPipeName);
+
+        // Act
+        CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
+
+        // Assert
+        var tracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
+        var dogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+
+        Assert.NotNull(tracePipeName);
+        Assert.NotNull(dogstatsdPipeName);
+        Assert.StartsWith(customTracePipeName + "_", tracePipeName);
+        Assert.StartsWith(customDogstatsdPipeName + "_", dogstatsdPipeName);
+        Assert.Equal(tracePipeName, startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"]);
+        Assert.Equal(dogstatsdPipeName, startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
+    }
+
+    [Fact]
+    public void ConfigureNamedPipes_ShouldAppendGuid_WhenPipeNameSet()
+    {
+        // Arrange
+        var startInfo = new System.Diagnostics.ProcessStartInfo();
+        const OS os = OS.Windows;
+        const string customTracePipeName = "custom_trace_pipe";
+        const string customDogstatsdPipeName = "custom_dogstatsd_pipe";
+
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", customTracePipeName);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", customDogstatsdPipeName);
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
+
+        // Act
+        CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
+
+        // Assert
+        var tracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
+        var dogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+
+        Assert.NotNull(tracePipeName);
+        Assert.NotNull(dogstatsdPipeName);
+        Assert.StartsWith(customTracePipeName + "_", tracePipeName);
+        Assert.StartsWith(customDogstatsdPipeName + "_", dogstatsdPipeName);
+        Assert.Equal(tracePipeName, startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"]);
+        Assert.Equal(dogstatsdPipeName, startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+    }
+
+    [Fact]
+    public void ConfigureNamedPipes_ShouldTruncateLongPipeNames()
+    {
+        // Arrange
+        var startInfo = new System.Diagnostics.ProcessStartInfo();
+        const OS os = OS.Windows;
+        var longPipeName = new string('a', 300); // 300 characters, exceeds limit
+
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", longPipeName);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", longPipeName);
+
+        // Act
+        CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
+
+        // Assert
+        var tracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
+        var dogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+
+        Assert.NotNull(tracePipeName);
+        Assert.NotNull(dogstatsdPipeName);
+        Assert.True(tracePipeName.Length <= 256);
+        Assert.True(dogstatsdPipeName.Length <= 256);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
+    }
+
+    [Fact]
+    public void ConfigureNamedPipes_ShouldGenerateUniquePipeNames_OnMultipleCalls()
+    {
+        // Arrange
+        var startInfo1 = new System.Diagnostics.ProcessStartInfo();
+        var startInfo2 = new System.Diagnostics.ProcessStartInfo();
+        const OS os = OS.Windows;
+
+        // Clear any existing pipe name configurations
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null);
+
+        // Act
+        CompatibilityLayer.ConfigureNamedPipes(startInfo1, os);
+        var tracePipeName1 = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
+        var dogstatsdPipeName1 = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+
+        // Clear environment variables to simulate a new function instance
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+
+        CompatibilityLayer.ConfigureNamedPipes(startInfo2, os);
+        var tracePipeName2 = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
+        var dogstatsdPipeName2 = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+
+        // Assert
+        Assert.NotEqual(tracePipeName1, tracePipeName2);
+        Assert.NotEqual(dogstatsdPipeName1, dogstatsdPipeName2);
+
+        // Cleanup
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", null);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", null);
+    }
 }
 

--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -219,7 +219,7 @@ public class CompatibilityLayerTests
         CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
 
         // Assert
-        var resultTracePipeName = startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"];
+        var resultTracePipeName = startInfo.EnvironmentVariables["DD_APM_WINDOWS_PIPE_NAME"];
         var resultDogstatsdPipeName = startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"];
 
         Assert.NotNull(resultTracePipeName);

--- a/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
+++ b/Datadog.Serverless.Compat.Tests/CompatibilityLayerTests.cs
@@ -116,107 +116,125 @@ public class CompatibilityLayerTests
         Assert.Equal(expected, result);
     }
 
-    [Theory]
-    [InlineData(null, "dd_trace_")] // Default name
-    [InlineData("custom_trace", "custom_trace_")] // WINDOWS_PIPE_NAME set
-    public void CalculateTracePipeName_ShouldGenerateUniqueName(string? traceWindowsPipeName, string expectedPrefix)
+    [Fact]
+    public void CalculateTracePipeName_ShouldGenerateUniqueName_WhenNoEnvVarSet()
     {
         // Arrange
-        using var _ = new EnvironmentVariableScope(("DD_TRACE_WINDOWS_PIPE_NAME", traceWindowsPipeName));
+        using var _ = new EnvironmentVariableScope(
+            ("DD_TRACE_WINDOWS_PIPE_NAME", null),
+            ("DD_TRACE_PIPE_NAME", null));
 
         // Act
         var pipeName1 = CompatibilityLayer.CalculateTracePipeName();
         var pipeName2 = CompatibilityLayer.CalculateTracePipeName();
 
         // Assert
-        Assert.NotNull(pipeName1);
-        Assert.NotNull(pipeName2);
-        Assert.StartsWith(expectedPrefix, pipeName1);
-        Assert.StartsWith(expectedPrefix, pipeName2);
-
-        // Each call should generate a unique GUID
+        Assert.StartsWith("dd_trace_", pipeName1);
+        Assert.StartsWith("dd_trace_", pipeName2);
         Assert.NotEqual(pipeName1, pipeName2);
-
-        // Format should be: {base}_{guid}
-        // GUID is 32 characters (N format)
-        Assert.Equal(expectedPrefix.Length + 32, pipeName1.Length);
+        Assert.Equal("dd_trace_".Length + 32, pipeName1.Length);
     }
 
     [Theory]
-    [InlineData(null, "dd_dogstatsd_")] // Default name
-    [InlineData("custom_dogstatsd", "custom_dogstatsd_")] // WINDOWS_PIPE_NAME set
-    public void CalculateDogStatsDPipeName_ShouldGenerateUniqueName(string? dogstatsdWindowsPipeName, string expectedPrefix)
+    [InlineData("DD_TRACE_WINDOWS_PIPE_NAME", "custom_trace")]
+    [InlineData("DD_TRACE_PIPE_NAME", "custom_trace")]
+    public void CalculateTracePipeName_ShouldReturnExactName_WhenEnvVarSet(string envVarName, string envVarValue)
     {
         // Arrange
-        using var _ = new EnvironmentVariableScope(("DD_DOGSTATSD_WINDOWS_PIPE_NAME", dogstatsdWindowsPipeName));
+        using var _ = new EnvironmentVariableScope(
+            ("DD_TRACE_WINDOWS_PIPE_NAME", null),
+            ("DD_TRACE_PIPE_NAME", null),
+            (envVarName, envVarValue));
+
+        // Act
+        var pipeName = CompatibilityLayer.CalculateTracePipeName();
+
+        // Assert — no GUID suffix when explicitly configured
+        Assert.Equal("custom_trace", pipeName);
+    }
+
+    [Fact]
+    public void CalculateDogStatsDPipeName_ShouldGenerateUniqueName_WhenNoEnvVarSet()
+    {
+        // Arrange
+        using var _ = new EnvironmentVariableScope(
+            ("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null),
+            ("DD_DOGSTATSD_PIPE_NAME", null));
 
         // Act
         var pipeName1 = CompatibilityLayer.CalculateDogStatsDPipeName();
         var pipeName2 = CompatibilityLayer.CalculateDogStatsDPipeName();
 
         // Assert
-        Assert.NotNull(pipeName1);
-        Assert.NotNull(pipeName2);
-        Assert.StartsWith(expectedPrefix, pipeName1);
-        Assert.StartsWith(expectedPrefix, pipeName2);
-
-        // Each call should generate a unique GUID
+        Assert.StartsWith("dd_dogstatsd_", pipeName1);
+        Assert.StartsWith("dd_dogstatsd_", pipeName2);
         Assert.NotEqual(pipeName1, pipeName2);
+        Assert.Equal("dd_dogstatsd_".Length + 32, pipeName1.Length);
+    }
 
-        // Format should be: {base}_{guid}
-        Assert.Equal(expectedPrefix.Length + 32, pipeName1.Length);
+    [Theory]
+    [InlineData("DD_DOGSTATSD_WINDOWS_PIPE_NAME", "custom_dogstatsd")]
+    [InlineData("DD_DOGSTATSD_PIPE_NAME", "custom_dogstatsd")]
+    public void CalculateDogStatsDPipeName_ShouldReturnExactName_WhenEnvVarSet(string envVarName, string envVarValue)
+    {
+        // Arrange
+        using var _ = new EnvironmentVariableScope(
+            ("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null),
+            ("DD_DOGSTATSD_PIPE_NAME", null),
+            (envVarName, envVarValue));
+
+        // Act
+        var pipeName = CompatibilityLayer.CalculateDogStatsDPipeName();
+
+        // Assert — no GUID suffix when explicitly configured
+        Assert.Equal("custom_dogstatsd", pipeName);
     }
 
     [Fact]
-    public void CalculateTracePipeName_ShouldTruncateBaseName_WhenTooLong()
+    public void CalculateTracePipeName_ShouldReturnExactName_EvenWhenLong()
     {
-        // Arrange
-        var longPipeName = new string('a', 300); // Exceeds max base length of 214
-        using var _ = new EnvironmentVariableScope(("DD_TRACE_WINDOWS_PIPE_NAME", longPipeName));
+        // Arrange — explicit pipe names are returned as-is (no GUID, no truncation)
+        var longPipeName = new string('a', 300);
+        using var _ = new EnvironmentVariableScope(
+            ("DD_TRACE_WINDOWS_PIPE_NAME", longPipeName),
+            ("DD_TRACE_PIPE_NAME", null));
 
         // Act
         var pipeName = CompatibilityLayer.CalculateTracePipeName();
 
         // Assert
-        Assert.NotNull(pipeName);
-        // Pipe name should be 247 chars: 214 (base) + 1 (underscore) + 32 (GUID)
-        Assert.Equal(247, pipeName.Length);
+        Assert.Equal(longPipeName, pipeName);
     }
 
     [Fact]
-    public void CalculateDogStatsDPipeName_ShouldTruncateBaseName_WhenTooLong()
+    public void CalculateDogStatsDPipeName_ShouldReturnExactName_EvenWhenLong()
     {
-        // Arrange
-        var longPipeName = new string('a', 300); // Exceeds max base length of 214
-        using var _ = new EnvironmentVariableScope(("DD_DOGSTATSD_WINDOWS_PIPE_NAME", longPipeName));
+        // Arrange — explicit pipe names are returned as-is (no GUID, no truncation)
+        var longPipeName = new string('a', 300);
+        using var _ = new EnvironmentVariableScope(
+            ("DD_DOGSTATSD_WINDOWS_PIPE_NAME", longPipeName),
+            ("DD_DOGSTATSD_PIPE_NAME", null));
 
         // Act
         var pipeName = CompatibilityLayer.CalculateDogStatsDPipeName();
 
         // Assert
-        Assert.NotNull(pipeName);
-        // Pipe name should be 247 chars: 214 (base) + 1 (underscore) + 32 (GUID)
-        Assert.Equal(247, pipeName.Length);
+        Assert.Equal(longPipeName, pipeName);
     }
 
-    [Theory]
-    [InlineData(null, null, "dd_trace_", "dd_dogstatsd_")] // Default names
-    [InlineData("custom_trace", "custom_dogstatsd", "custom_trace_", "custom_dogstatsd_")] // WINDOWS_PIPE_NAME set
-    public void ConfigureNamedPipes_ShouldPassPipeNamesToStartInfo_OnWindows(
-        string? traceWindowsPipeName,
-        string? dogstatsdWindowsPipeName,
-        string expectedTracePrefix,
-        string expectedDogstatsdPrefix)
+    [Fact]
+    public void ConfigureNamedPipes_ShouldGenerateGuidSuffixedNames_WhenNoEnvVarsSet()
     {
         // Arrange
         using var _ = new EnvironmentVariableScope(
-            ("DD_TRACE_WINDOWS_PIPE_NAME", traceWindowsPipeName),
-            ("DD_DOGSTATSD_WINDOWS_PIPE_NAME", dogstatsdWindowsPipeName));
+            ("DD_TRACE_WINDOWS_PIPE_NAME", null),
+            ("DD_TRACE_PIPE_NAME", null),
+            ("DD_DOGSTATSD_WINDOWS_PIPE_NAME", null),
+            ("DD_DOGSTATSD_PIPE_NAME", null));
         var startInfo = new System.Diagnostics.ProcessStartInfo();
-        const OS os = OS.Windows;
 
         // Act
-        CompatibilityLayer.ConfigureNamedPipes(startInfo, os);
+        CompatibilityLayer.ConfigureNamedPipes(startInfo, OS.Windows);
 
         // Assert
         var resultTracePipeName = startInfo.EnvironmentVariables["DD_APM_WINDOWS_PIPE_NAME"];
@@ -224,8 +242,27 @@ public class CompatibilityLayerTests
 
         Assert.NotNull(resultTracePipeName);
         Assert.NotNull(resultDogstatsdPipeName);
-        Assert.StartsWith(expectedTracePrefix, resultTracePipeName);
-        Assert.StartsWith(expectedDogstatsdPrefix, resultDogstatsdPipeName);
+        Assert.StartsWith("dd_trace_", resultTracePipeName);
+        Assert.StartsWith("dd_dogstatsd_", resultDogstatsdPipeName);
+    }
+
+    [Fact]
+    public void ConfigureNamedPipes_ShouldUseExactNames_WhenEnvVarsSet()
+    {
+        // Arrange
+        using var _ = new EnvironmentVariableScope(
+            ("DD_TRACE_WINDOWS_PIPE_NAME", "custom_trace"),
+            ("DD_TRACE_PIPE_NAME", null),
+            ("DD_DOGSTATSD_WINDOWS_PIPE_NAME", "custom_dogstatsd"),
+            ("DD_DOGSTATSD_PIPE_NAME", null));
+        var startInfo = new System.Diagnostics.ProcessStartInfo();
+
+        // Act
+        CompatibilityLayer.ConfigureNamedPipes(startInfo, OS.Windows);
+
+        // Assert
+        Assert.Equal("custom_trace", startInfo.EnvironmentVariables["DD_APM_WINDOWS_PIPE_NAME"]);
+        Assert.Equal("custom_dogstatsd", startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"]);
     }
 
     [Fact]

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -194,9 +194,21 @@ public static class CompatibilityLayer
 
     /// <summary>
     /// Calculates the trace pipe name with a unique GUID suffix.
-    /// This method is instrumented by the Datadog tracer to override the return value.
-    /// When the tracer is present, it will return the tracer's pre-generated pipe name.
+    /// When the Datadog tracer is present, its calltarget instrumentation overrides the
+    /// return value with the tracer's pre-generated pipe name, so both sides use the same name.
     /// When no tracer is present, this method generates its own unique pipe name.
+    ///
+    /// *** INSTRUMENTATION CONTRACT — DO NOT RENAME OR CHANGE SIGNATURE ***
+    /// The dd-trace-dotnet tracer targets this exact symbol at runtime:
+    ///   Assembly  : Datadog.Serverless.Compat
+    ///   Type      : Datadog.Serverless.CompatibilityLayer
+    ///   Method    : CalculateTracePipeName
+    ///   Parameters: (none)
+    ///   Returns   : System.String
+    ///   Versions  : 0.0.0 – 1.*.*
+    /// Renaming, moving, or adding parameters silently disables the integration —
+    /// the native profiler skips unrecognised symbols without throwing.
+    /// A 2.x major bump also escapes the version range and requires a coordinated tracer update.
     /// </summary>
     /// <returns>The trace pipe name to use for communication with the agent</returns>
     public static string CalculateTracePipeName()
@@ -221,9 +233,21 @@ public static class CompatibilityLayer
 
     /// <summary>
     /// Calculates the DogStatsD pipe name with a unique GUID suffix.
-    /// This method is instrumented by the Datadog tracer to override the return value.
-    /// When the tracer is present, it will return the tracer's pre-generated pipe name.
+    /// When the Datadog tracer is present, its calltarget instrumentation overrides the
+    /// return value with the tracer's pre-generated pipe name, so both sides use the same name.
     /// When no tracer is present, this method generates its own unique pipe name.
+    ///
+    /// *** INSTRUMENTATION CONTRACT — DO NOT RENAME OR CHANGE SIGNATURE ***
+    /// The dd-trace-dotnet tracer targets this exact symbol at runtime:
+    ///   Assembly  : Datadog.Serverless.Compat
+    ///   Type      : Datadog.Serverless.CompatibilityLayer
+    ///   Method    : CalculateDogStatsDPipeName
+    ///   Parameters: (none)
+    ///   Returns   : System.String
+    ///   Versions  : 0.0.0 – 1.*.*
+    /// Renaming, moving, or adding parameters silently disables the integration —
+    /// the native profiler skips unrecognised symbols without throwing.
+    /// A 2.x major bump also escapes the version range and requires a coordinated tracer update.
     /// </summary>
     /// <returns>The DogStatsD pipe name to use for communication with the agent</returns>
     public static string CalculateDogStatsDPipeName()
@@ -260,22 +284,16 @@ public static class CompatibilityLayer
         var tracePipeName = CalculateTracePipeName();
         var dogstatsdPipeName = CalculateDogStatsDPipeName();
 
-        // Ensure pipe names are not null before setting environment variables
-        if (tracePipeName == null || dogstatsdPipeName == null)
-        {
-            Logger.LogError("Failed to calculate pipe names. Trace and DogStatsD pipe names cannot be null.");
-            return;
-        }
-
-        // Set environment variables for the spawned rust binary
+        // The trace pipe name flows tracer → DD_APM_WINDOWS_PIPE_NAME → mini-agent.
+        // The tracer reads its own ExporterSettings (already set before this hook fires)
+        // and the mini-agent reads DD_APM_WINDOWS_PIPE_NAME from its spawned-process env.
+        // There is no in-process consumer of DD_TRACE_PIPE_NAME at this stage.
         startInfo.EnvironmentVariables["DD_APM_WINDOWS_PIPE_NAME"] = tracePipeName;
         startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"] = dogstatsdPipeName;
 
-        // Set pipe names in the current process so that in-process consumers
-        // (e.g. the DogStatsD client) can discover the pipe to connect to.
-        // This runs during the DOTNET_STARTUP_HOOKS phase, before user code
-        // calls DogStatsdService.Configure(), so the env vars will be visible.
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", tracePipeName);
+        // Expose the DogStatsD pipe name in the current process so the DogStatsD client SDK
+        // can discover it. DogStatsdService.Configure() is called lazily in user code after
+        // this hook runs, so the env var will be visible when it reads DD_DOGSTATSD_PIPE_NAME.
         Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", dogstatsdPipeName);
 
         Logger.LogInformation($"Configured named pipes - Trace: {tracePipeName}, DogStatsD: {dogstatsdPipeName}");

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -150,7 +150,7 @@ public static class CompatibilityLayer
         return Environment.GetEnvironmentVariable("WEBSITE_SKU") == "FlexConsumption" && Environment.GetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP") == null;
     }
 
-    private static string DeterminePipeBaseName(string windowsPipeNameKey, string pipeNameKey, string defaultName)
+    private static string? DeterminePipeBaseName(string windowsPipeNameKey, string pipeNameKey, string? defaultName)
     {
         var windowsPipeName = Environment.GetEnvironmentVariable(windowsPipeNameKey);
         var pipeName = Environment.GetEnvironmentVariable(pipeNameKey);
@@ -164,12 +164,17 @@ public static class CompatibilityLayer
             return windowsPipeName;
         }
 
-        return !string.IsNullOrEmpty(pipeName) ? pipeName : defaultName;
+        if (!string.IsNullOrEmpty(pipeName))
+        {
+            return pipeName;
+        }
+
+        return defaultName;
     }
 
     private static string CalculatePipeName(string windowsPipeNameKey, string pipeNameKey, string defaultName, string logContext)
     {
-        var pipeBase = DeterminePipeBaseName(windowsPipeNameKey, pipeNameKey, defaultName);
+        var pipeBase = DeterminePipeBaseName(windowsPipeNameKey, pipeNameKey, defaultName)!;
 
         // Windows pipe max: 256 chars - "\\.\pipe\" (9) - "_" (1) - GUID (32) = 214
         const int maxBaseLength = 214;
@@ -196,6 +201,17 @@ public static class CompatibilityLayer
     /// <returns>The trace pipe name to use for communication with the agent</returns>
     public static string CalculateTracePipeName()
     {
+        var explicitName = DeterminePipeBaseName(
+            "DD_TRACE_WINDOWS_PIPE_NAME",
+            "DD_TRACE_PIPE_NAME",
+            defaultName: null);
+
+        if (explicitName != null)
+        {
+            Logger.LogDebug($"Using explicitly configured trace pipe name: {explicitName}");
+            return explicitName;
+        }
+
         return CalculatePipeName(
             "DD_TRACE_WINDOWS_PIPE_NAME",
             "DD_TRACE_PIPE_NAME",
@@ -212,6 +228,17 @@ public static class CompatibilityLayer
     /// <returns>The DogStatsD pipe name to use for communication with the agent</returns>
     public static string CalculateDogStatsDPipeName()
     {
+        var explicitName = DeterminePipeBaseName(
+            "DD_DOGSTATSD_WINDOWS_PIPE_NAME",
+            "DD_DOGSTATSD_PIPE_NAME",
+            defaultName: null);
+
+        if (explicitName != null)
+        {
+            Logger.LogDebug($"Using explicitly configured DogStatsD pipe name: {explicitName}");
+            return explicitName;
+        }
+
         return CalculatePipeName(
             "DD_DOGSTATSD_WINDOWS_PIPE_NAME",
             "DD_DOGSTATSD_PIPE_NAME",

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -271,6 +271,13 @@ public static class CompatibilityLayer
         startInfo.EnvironmentVariables["DD_APM_WINDOWS_PIPE_NAME"] = tracePipeName;
         startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"] = dogstatsdPipeName;
 
+        // Set pipe names in the current process so that in-process consumers
+        // (e.g. the DogStatsD client) can discover the pipe to connect to.
+        // This runs during the DOTNET_STARTUP_HOOKS phase, before user code
+        // calls DogStatsdService.Configure(), so the env vars will be visible.
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", tracePipeName);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", dogstatsdPipeName);
+
         Logger.LogInformation($"Configured named pipes - Trace: {tracePipeName}, DogStatsD: {dogstatsdPipeName}");
     }
 

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -167,28 +167,19 @@ public static class CompatibilityLayer
         return !string.IsNullOrEmpty(pipeName) ? pipeName : defaultName;
     }
 
-    internal static void ConfigureNamedPipes(ProcessStartInfo startInfo, OS os)
+    /// <summary>
+    /// Calculates the trace pipe name with a unique GUID suffix.
+    /// This method is instrumented by the Datadog tracer to override the return value.
+    /// When the tracer is present, it will return the tracer's pre-generated pipe name.
+    /// When no tracer is present, this method generates its own unique pipe name.
+    /// </summary>
+    /// <returns>The trace pipe name to use for communication with the agent</returns>
+    public static string CalculateTracePipeName()
     {
-        // Only configure named pipes for Windows
-        if (os != OS.Windows)
-        {
-            return;
-        }
-
-        // Generate a unique GUID for this function instance to avoid conflicts
-        // when multiple Azure Functions run in the same namespace
-        var functionGuid = Guid.NewGuid().ToString("N"); // "N" format removes hyphens
-
-        // Determine base pipe names (priority: WINDOWS_PIPE_NAME > PIPE_NAME > default)
         var tracePipeBase = DeterminePipeBaseName(
             "DD_TRACE_WINDOWS_PIPE_NAME",
             "DD_TRACE_PIPE_NAME",
             "dd_trace");
-
-        var dogstatsdPipeBase = DeterminePipeBaseName(
-            "DD_DOGSTATSD_WINDOWS_PIPE_NAME",
-            "DD_DOGSTATSD_PIPE_NAME",
-            "dd_dogstatsd");
 
         // Validate base pipe name length before appending GUID
         // Windows pipe path: \\.\pipe\{base}_{guid}
@@ -201,25 +192,62 @@ public static class CompatibilityLayer
             tracePipeBase = tracePipeBase.Substring(0, maxBaseLength);
         }
 
+        var guid = Guid.NewGuid().ToString("N");
+        var pipeName = $"{tracePipeBase}_{guid}";
+
+        Logger.LogDebug($"CompatibilityLayer calculated trace pipe name: {pipeName}");
+        return pipeName;
+    }
+
+    /// <summary>
+    /// Calculates the DogStatsD pipe name with a unique GUID suffix.
+    /// This method is instrumented by the Datadog tracer to override the return value.
+    /// When the tracer is present, it will return the tracer's pre-generated pipe name.
+    /// When no tracer is present, this method generates its own unique pipe name.
+    /// </summary>
+    /// <returns>The DogStatsD pipe name to use for communication with the agent</returns>
+    public static string CalculateDogStatsDPipeName()
+    {
+        var dogstatsdPipeBase = DeterminePipeBaseName(
+            "DD_DOGSTATSD_WINDOWS_PIPE_NAME",
+            "DD_DOGSTATSD_PIPE_NAME",
+            "dd_dogstatsd");
+
+        // Validate base pipe name length before appending GUID
+        const int maxBaseLength = 214;
+
         if (dogstatsdPipeBase.Length > maxBaseLength)
         {
             Logger.LogWarning($"DogStatsD pipe base name exceeds {maxBaseLength} characters ({dogstatsdPipeBase.Length}). Truncating to allow for GUID.");
             dogstatsdPipeBase = dogstatsdPipeBase.Substring(0, maxBaseLength);
         }
 
-        // Always append full GUID to ensure uniqueness across multiple function instances
-        var tracePipeName = $"{tracePipeBase}_{functionGuid}";
-        var dogstatsdPipeName = $"{dogstatsdPipeBase}_{functionGuid}";
+        var guid = Guid.NewGuid().ToString("N");
+        var pipeName = $"{dogstatsdPipeBase}_{guid}";
 
-        // Set environment variables for tracer and dogstatsd libraries (process-wide)
-        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", tracePipeName);
-        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", dogstatsdPipeName);
+        Logger.LogDebug($"CompatibilityLayer calculated DogStatsD pipe name: {pipeName}");
+        return pipeName;
+    }
+
+    internal static void ConfigureNamedPipes(ProcessStartInfo startInfo, OS os)
+    {
+        // Only configure named pipes for Windows
+        if (os != OS.Windows)
+        {
+            return;
+        }
+
+        // Call the public methods that can be instrumented by the tracer
+        // If tracer is present: instrumentation will override the return values
+        // If no tracer: methods will generate their own unique pipe names
+        var tracePipeName = CalculateTracePipeName();
+        var dogstatsdPipeName = CalculateDogStatsDPipeName();
 
         // Set environment variables for the spawned rust binary
         startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"] = tracePipeName;
         startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"] = dogstatsdPipeName;
 
-        Logger.LogDebug($"Configured named pipes - Trace: {tracePipeName}, DogStatsD: {dogstatsdPipeName}");
+        Logger.LogInformation($"Configured named pipes - Trace: {tracePipeName}, DogStatsD: {dogstatsdPipeName}");
     }
 
     public static void Start()

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -150,7 +150,7 @@ public static class CompatibilityLayer
         return Environment.GetEnvironmentVariable("WEBSITE_SKU") == "FlexConsumption" && Environment.GetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP") == null;
     }
 
-    private static string? DeterminePipeBaseName(string windowsPipeNameKey, string pipeNameKey, string? defaultName)
+    private static string? DeterminePipeBaseName(string windowsPipeNameKey, string pipeNameKey)
     {
         var windowsPipeName = Environment.GetEnvironmentVariable(windowsPipeNameKey);
         var pipeName = Environment.GetEnvironmentVariable(pipeNameKey);
@@ -169,27 +169,7 @@ public static class CompatibilityLayer
             return pipeName;
         }
 
-        return defaultName;
-    }
-
-    private static string CalculatePipeName(string windowsPipeNameKey, string pipeNameKey, string defaultName, string logContext)
-    {
-        var pipeBase = DeterminePipeBaseName(windowsPipeNameKey, pipeNameKey, defaultName)!;
-
-        // Windows pipe max: 256 chars - "\\.\pipe\" (9) - "_" (1) - GUID (32) = 214
-        const int maxBaseLength = 214;
-
-        if (pipeBase.Length > maxBaseLength)
-        {
-            Logger.LogWarning($"{logContext} pipe base name exceeds {maxBaseLength} characters ({pipeBase.Length}). Truncating to allow for GUID.");
-            pipeBase = pipeBase.Substring(0, maxBaseLength);
-        }
-
-        var guid = Guid.NewGuid().ToString("N");
-        var pipeName = $"{pipeBase}_{guid}";
-
-        Logger.LogDebug($"CompatibilityLayer calculated {logContext} pipe name: {pipeName}");
-        return pipeName;
+        return null;
     }
 
     /// <summary>
@@ -215,8 +195,7 @@ public static class CompatibilityLayer
     {
         var explicitName = DeterminePipeBaseName(
             "DD_TRACE_WINDOWS_PIPE_NAME",
-            "DD_TRACE_PIPE_NAME",
-            defaultName: null);
+            "DD_TRACE_PIPE_NAME");
 
         if (explicitName != null)
         {
@@ -224,11 +203,9 @@ public static class CompatibilityLayer
             return explicitName;
         }
 
-        return CalculatePipeName(
-            "DD_TRACE_WINDOWS_PIPE_NAME",
-            "DD_TRACE_PIPE_NAME",
-            "dd_trace",
-            "trace");
+        var pipeName = $"dd_trace_{Guid.NewGuid():N}";
+        Logger.LogDebug($"CompatibilityLayer calculated trace pipe name: {pipeName}");
+        return pipeName;
     }
 
     /// <summary>
@@ -254,8 +231,7 @@ public static class CompatibilityLayer
     {
         var explicitName = DeterminePipeBaseName(
             "DD_DOGSTATSD_WINDOWS_PIPE_NAME",
-            "DD_DOGSTATSD_PIPE_NAME",
-            defaultName: null);
+            "DD_DOGSTATSD_PIPE_NAME");
 
         if (explicitName != null)
         {
@@ -263,11 +239,9 @@ public static class CompatibilityLayer
             return explicitName;
         }
 
-        return CalculatePipeName(
-            "DD_DOGSTATSD_WINDOWS_PIPE_NAME",
-            "DD_DOGSTATSD_PIPE_NAME",
-            "dd_dogstatsd",
-            "DogStatsD");
+        var pipeName = $"dd_dogstatsd_{Guid.NewGuid():N}";
+        Logger.LogDebug($"CompatibilityLayer calculated DogStatsD pipe name: {pipeName}");
+        return pipeName;
     }
 
     internal static void ConfigureNamedPipes(ProcessStartInfo startInfo, OS os)

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -150,6 +150,23 @@ public static class CompatibilityLayer
         return Environment.GetEnvironmentVariable("WEBSITE_SKU") == "FlexConsumption" && Environment.GetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP") == null;
     }
 
+    private static string DeterminePipeBaseName(string windowsPipeNameKey, string pipeNameKey, string defaultName)
+    {
+        var windowsPipeName = Environment.GetEnvironmentVariable(windowsPipeNameKey);
+        var pipeName = Environment.GetEnvironmentVariable(pipeNameKey);
+
+        if (!string.IsNullOrEmpty(windowsPipeName))
+        {
+            if (!string.IsNullOrEmpty(pipeName) && pipeName != windowsPipeName)
+            {
+                Logger.LogWarning($"{pipeNameKey} ('{pipeName}') differs from {windowsPipeNameKey} ('{windowsPipeName}'). Using {windowsPipeNameKey}.");
+            }
+            return windowsPipeName;
+        }
+
+        return !string.IsNullOrEmpty(pipeName) ? pipeName : defaultName;
+    }
+
     internal static void ConfigureNamedPipes(ProcessStartInfo startInfo, OS os)
     {
         // Only configure named pipes for Windows
@@ -162,68 +179,36 @@ public static class CompatibilityLayer
         // when multiple Azure Functions run in the same namespace
         var functionGuid = Guid.NewGuid().ToString("N"); // "N" format removes hyphens
 
-        // Check for existing configurations
-        var existingTraceWindowsPipeName = Environment.GetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME");
-        var existingTracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
-        var existingDogstatsdWindowsPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME");
-        var existingDogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+        // Determine base pipe names (priority: WINDOWS_PIPE_NAME > PIPE_NAME > default)
+        var tracePipeBase = DeterminePipeBaseName(
+            "DD_TRACE_WINDOWS_PIPE_NAME",
+            "DD_TRACE_PIPE_NAME",
+            "dd_trace");
 
-        // Determine trace pipe name base
-        // Priority: DD_TRACE_WINDOWS_PIPE_NAME (rust binary) > DD_TRACE_PIPE_NAME (tracer) > default
-        string tracePipeBase;
-        if (!string.IsNullOrEmpty(existingTraceWindowsPipeName))
+        var dogstatsdPipeBase = DeterminePipeBaseName(
+            "DD_DOGSTATSD_WINDOWS_PIPE_NAME",
+            "DD_DOGSTATSD_PIPE_NAME",
+            "dd_dogstatsd");
+
+        // Validate base pipe name length before appending GUID
+        // Max length: 256 - 1 (underscore) - 32 (GUID without hyphens) = 223
+        const int maxBaseLength = 223;
+
+        if (tracePipeBase.Length > maxBaseLength)
         {
-            tracePipeBase = existingTraceWindowsPipeName;
-            if (!string.IsNullOrEmpty(existingTracePipeName) && existingTracePipeName != tracePipeBase)
-            {
-                Logger.LogWarning($"DD_TRACE_PIPE_NAME ('{existingTracePipeName}') differs from DD_TRACE_WINDOWS_PIPE_NAME ('{tracePipeBase}'). Using DD_TRACE_WINDOWS_PIPE_NAME.");
-            }
-        }
-        else if (!string.IsNullOrEmpty(existingTracePipeName))
-        {
-            tracePipeBase = existingTracePipeName;
-        }
-        else
-        {
-            tracePipeBase = "dd_trace";
+            Logger.LogWarning($"Trace pipe base name exceeds {maxBaseLength} characters ({tracePipeBase.Length}). Truncating to allow for GUID.");
+            tracePipeBase = tracePipeBase.Substring(0, maxBaseLength);
         }
 
-        // Determine dogstatsd pipe name base
-        // Priority: DD_DOGSTATSD_WINDOWS_PIPE_NAME (rust binary) > DD_DOGSTATSD_PIPE_NAME (dogstatsd) > default
-        string dogstatsdPipeBase;
-        if (!string.IsNullOrEmpty(existingDogstatsdWindowsPipeName))
+        if (dogstatsdPipeBase.Length > maxBaseLength)
         {
-            dogstatsdPipeBase = existingDogstatsdWindowsPipeName;
-            if (!string.IsNullOrEmpty(existingDogstatsdPipeName) && existingDogstatsdPipeName != dogstatsdPipeBase)
-            {
-                Logger.LogWarning($"DD_DOGSTATSD_PIPE_NAME ('{existingDogstatsdPipeName}') differs from DD_DOGSTATSD_WINDOWS_PIPE_NAME ('{dogstatsdPipeBase}'). Using DD_DOGSTATSD_WINDOWS_PIPE_NAME.");
-            }
-        }
-        else if (!string.IsNullOrEmpty(existingDogstatsdPipeName))
-        {
-            dogstatsdPipeBase = existingDogstatsdPipeName;
-        }
-        else
-        {
-            dogstatsdPipeBase = "dd_dogstatsd";
+            Logger.LogWarning($"DogStatsD pipe base name exceeds {maxBaseLength} characters ({dogstatsdPipeBase.Length}). Truncating to allow for GUID.");
+            dogstatsdPipeBase = dogstatsdPipeBase.Substring(0, maxBaseLength);
         }
 
-        // Always append GUID to ensure uniqueness across multiple function instances
+        // Always append full GUID to ensure uniqueness across multiple function instances
         var tracePipeName = $"{tracePipeBase}_{functionGuid}";
         var dogstatsdPipeName = $"{dogstatsdPipeBase}_{functionGuid}";
-
-        // Ensure pipe names don't exceed Windows limit of 256 characters
-        if (tracePipeName.Length > 256)
-        {
-            Logger.LogWarning($"Trace pipe name exceeds 256 characters ({tracePipeName.Length}). Truncating.");
-            tracePipeName = tracePipeName.Substring(0, 256);
-        }
-
-        if (dogstatsdPipeName.Length > 256)
-        {
-            Logger.LogWarning($"DogStatsD pipe name exceeds 256 characters ({dogstatsdPipeName.Length}). Truncating.");
-            dogstatsdPipeName = dogstatsdPipeName.Substring(0, 256);
-        }
 
         // Set environment variables for tracer and dogstatsd libraries (process-wide)
         Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", tracePipeName);

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -191,8 +191,9 @@ public static class CompatibilityLayer
             "dd_dogstatsd");
 
         // Validate base pipe name length before appending GUID
-        // Max length: 256 - 1 (underscore) - 32 (GUID without hyphens) = 223
-        const int maxBaseLength = 223;
+        // Windows pipe path: \\.\pipe\{base}_{guid}
+        // Max total: 256 - 9 (\\.\pipe\) - 1 (underscore) - 32 (GUID) = 214
+        const int maxBaseLength = 214;
 
         if (tracePipeBase.Length > maxBaseLength)
         {

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -241,7 +241,7 @@ public static class CompatibilityLayer
         }
 
         // Set environment variables for the spawned rust binary
-        startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"] = tracePipeName;
+        startInfo.EnvironmentVariables["DD_APM_WINDOWS_PIPE_NAME"] = tracePipeName;
         startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"] = dogstatsdPipeName;
 
         Logger.LogInformation($"Configured named pipes - Trace: {tracePipeName}, DogStatsD: {dogstatsdPipeName}");

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -167,6 +167,26 @@ public static class CompatibilityLayer
         return !string.IsNullOrEmpty(pipeName) ? pipeName : defaultName;
     }
 
+    private static string CalculatePipeName(string windowsPipeNameKey, string pipeNameKey, string defaultName, string logContext)
+    {
+        var pipeBase = DeterminePipeBaseName(windowsPipeNameKey, pipeNameKey, defaultName);
+
+        // Windows pipe max: 256 chars - "\\.\pipe\" (9) - "_" (1) - GUID (32) = 214
+        const int maxBaseLength = 214;
+
+        if (pipeBase.Length > maxBaseLength)
+        {
+            Logger.LogWarning($"{logContext} pipe base name exceeds {maxBaseLength} characters ({pipeBase.Length}). Truncating to allow for GUID.");
+            pipeBase = pipeBase.Substring(0, maxBaseLength);
+        }
+
+        var guid = Guid.NewGuid().ToString("N");
+        var pipeName = $"{pipeBase}_{guid}";
+
+        Logger.LogDebug($"CompatibilityLayer calculated {logContext} pipe name: {pipeName}");
+        return pipeName;
+    }
+
     /// <summary>
     /// Calculates the trace pipe name with a unique GUID suffix.
     /// This method is instrumented by the Datadog tracer to override the return value.
@@ -176,27 +196,11 @@ public static class CompatibilityLayer
     /// <returns>The trace pipe name to use for communication with the agent</returns>
     public static string CalculateTracePipeName()
     {
-        var tracePipeBase = DeterminePipeBaseName(
+        return CalculatePipeName(
             "DD_TRACE_WINDOWS_PIPE_NAME",
             "DD_TRACE_PIPE_NAME",
-            "dd_trace");
-
-        // Validate base pipe name length before appending GUID
-        // Windows pipe path: \\.\pipe\{base}_{guid}
-        // Max total: 256 - 9 (\\.\pipe\) - 1 (underscore) - 32 (GUID) = 214
-        const int maxBaseLength = 214;
-
-        if (tracePipeBase.Length > maxBaseLength)
-        {
-            Logger.LogWarning($"Trace pipe base name exceeds {maxBaseLength} characters ({tracePipeBase.Length}). Truncating to allow for GUID.");
-            tracePipeBase = tracePipeBase.Substring(0, maxBaseLength);
-        }
-
-        var guid = Guid.NewGuid().ToString("N");
-        var pipeName = $"{tracePipeBase}_{guid}";
-
-        Logger.LogDebug($"CompatibilityLayer calculated trace pipe name: {pipeName}");
-        return pipeName;
+            "dd_trace",
+            "trace");
     }
 
     /// <summary>
@@ -208,25 +212,11 @@ public static class CompatibilityLayer
     /// <returns>The DogStatsD pipe name to use for communication with the agent</returns>
     public static string CalculateDogStatsDPipeName()
     {
-        var dogstatsdPipeBase = DeterminePipeBaseName(
+        return CalculatePipeName(
             "DD_DOGSTATSD_WINDOWS_PIPE_NAME",
             "DD_DOGSTATSD_PIPE_NAME",
-            "dd_dogstatsd");
-
-        // Validate base pipe name length before appending GUID
-        const int maxBaseLength = 214;
-
-        if (dogstatsdPipeBase.Length > maxBaseLength)
-        {
-            Logger.LogWarning($"DogStatsD pipe base name exceeds {maxBaseLength} characters ({dogstatsdPipeBase.Length}). Truncating to allow for GUID.");
-            dogstatsdPipeBase = dogstatsdPipeBase.Substring(0, maxBaseLength);
-        }
-
-        var guid = Guid.NewGuid().ToString("N");
-        var pipeName = $"{dogstatsdPipeBase}_{guid}";
-
-        Logger.LogDebug($"CompatibilityLayer calculated DogStatsD pipe name: {pipeName}");
-        return pipeName;
+            "dd_dogstatsd",
+            "DogStatsD");
     }
 
     internal static void ConfigureNamedPipes(ProcessStartInfo startInfo, OS os)
@@ -242,6 +232,13 @@ public static class CompatibilityLayer
         // If no tracer: methods will generate their own unique pipe names
         var tracePipeName = CalculateTracePipeName();
         var dogstatsdPipeName = CalculateDogStatsDPipeName();
+
+        // Ensure pipe names are not null before setting environment variables
+        if (tracePipeName == null || dogstatsdPipeName == null)
+        {
+            Logger.LogError("Failed to calculate pipe names. Trace and DogStatsD pipe names cannot be null.");
+            return;
+        }
 
         // Set environment variables for the spawned rust binary
         startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"] = tracePipeName;

--- a/Datadog.Serverless/CompatibilityLayer.cs
+++ b/Datadog.Serverless/CompatibilityLayer.cs
@@ -150,6 +150,92 @@ public static class CompatibilityLayer
         return Environment.GetEnvironmentVariable("WEBSITE_SKU") == "FlexConsumption" && Environment.GetEnvironmentVariable("DD_AZURE_RESOURCE_GROUP") == null;
     }
 
+    internal static void ConfigureNamedPipes(ProcessStartInfo startInfo, OS os)
+    {
+        // Only configure named pipes for Windows
+        if (os != OS.Windows)
+        {
+            return;
+        }
+
+        // Generate a unique GUID for this function instance to avoid conflicts
+        // when multiple Azure Functions run in the same namespace
+        var functionGuid = Guid.NewGuid().ToString("N"); // "N" format removes hyphens
+
+        // Check for existing configurations
+        var existingTraceWindowsPipeName = Environment.GetEnvironmentVariable("DD_TRACE_WINDOWS_PIPE_NAME");
+        var existingTracePipeName = Environment.GetEnvironmentVariable("DD_TRACE_PIPE_NAME");
+        var existingDogstatsdWindowsPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_WINDOWS_PIPE_NAME");
+        var existingDogstatsdPipeName = Environment.GetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME");
+
+        // Determine trace pipe name base
+        // Priority: DD_TRACE_WINDOWS_PIPE_NAME (rust binary) > DD_TRACE_PIPE_NAME (tracer) > default
+        string tracePipeBase;
+        if (!string.IsNullOrEmpty(existingTraceWindowsPipeName))
+        {
+            tracePipeBase = existingTraceWindowsPipeName;
+            if (!string.IsNullOrEmpty(existingTracePipeName) && existingTracePipeName != tracePipeBase)
+            {
+                Logger.LogWarning($"DD_TRACE_PIPE_NAME ('{existingTracePipeName}') differs from DD_TRACE_WINDOWS_PIPE_NAME ('{tracePipeBase}'). Using DD_TRACE_WINDOWS_PIPE_NAME.");
+            }
+        }
+        else if (!string.IsNullOrEmpty(existingTracePipeName))
+        {
+            tracePipeBase = existingTracePipeName;
+        }
+        else
+        {
+            tracePipeBase = "dd_trace";
+        }
+
+        // Determine dogstatsd pipe name base
+        // Priority: DD_DOGSTATSD_WINDOWS_PIPE_NAME (rust binary) > DD_DOGSTATSD_PIPE_NAME (dogstatsd) > default
+        string dogstatsdPipeBase;
+        if (!string.IsNullOrEmpty(existingDogstatsdWindowsPipeName))
+        {
+            dogstatsdPipeBase = existingDogstatsdWindowsPipeName;
+            if (!string.IsNullOrEmpty(existingDogstatsdPipeName) && existingDogstatsdPipeName != dogstatsdPipeBase)
+            {
+                Logger.LogWarning($"DD_DOGSTATSD_PIPE_NAME ('{existingDogstatsdPipeName}') differs from DD_DOGSTATSD_WINDOWS_PIPE_NAME ('{dogstatsdPipeBase}'). Using DD_DOGSTATSD_WINDOWS_PIPE_NAME.");
+            }
+        }
+        else if (!string.IsNullOrEmpty(existingDogstatsdPipeName))
+        {
+            dogstatsdPipeBase = existingDogstatsdPipeName;
+        }
+        else
+        {
+            dogstatsdPipeBase = "dd_dogstatsd";
+        }
+
+        // Always append GUID to ensure uniqueness across multiple function instances
+        var tracePipeName = $"{tracePipeBase}_{functionGuid}";
+        var dogstatsdPipeName = $"{dogstatsdPipeBase}_{functionGuid}";
+
+        // Ensure pipe names don't exceed Windows limit of 256 characters
+        if (tracePipeName.Length > 256)
+        {
+            Logger.LogWarning($"Trace pipe name exceeds 256 characters ({tracePipeName.Length}). Truncating.");
+            tracePipeName = tracePipeName.Substring(0, 256);
+        }
+
+        if (dogstatsdPipeName.Length > 256)
+        {
+            Logger.LogWarning($"DogStatsD pipe name exceeds 256 characters ({dogstatsdPipeName.Length}). Truncating.");
+            dogstatsdPipeName = dogstatsdPipeName.Substring(0, 256);
+        }
+
+        // Set environment variables for tracer and dogstatsd libraries (process-wide)
+        Environment.SetEnvironmentVariable("DD_TRACE_PIPE_NAME", tracePipeName);
+        Environment.SetEnvironmentVariable("DD_DOGSTATSD_PIPE_NAME", dogstatsdPipeName);
+
+        // Set environment variables for the spawned rust binary
+        startInfo.EnvironmentVariables["DD_TRACE_WINDOWS_PIPE_NAME"] = tracePipeName;
+        startInfo.EnvironmentVariables["DD_DOGSTATSD_WINDOWS_PIPE_NAME"] = dogstatsdPipeName;
+
+        Logger.LogDebug($"Configured named pipes - Trace: {tracePipeName}, DogStatsD: {dogstatsdPipeName}");
+    }
+
     public static void Start()
     {
         // detect values
@@ -229,6 +315,9 @@ public static class CompatibilityLayer
             };
 
             startInfo.EnvironmentVariables["DD_SERVERLESS_COMPAT_VERSION"] = packageVersion;
+
+            // Configure named pipes with unique names to avoid conflicts in multi-function scenarios
+            ConfigureNamedPipes(startInfo, os);
 
             var process = new Process { StartInfo = startInfo };
             process.Start();


### PR DESCRIPTION
### What does this PR do?
* Configure unique windows named pipes. 
* Coordinates with the tracer layer via instrumentation. Exposes public methods for pipe name calculation which work smoothly if the tracer is not present. See: https://github.com/DataDog/dd-trace-dotnet/pull/8164
* Coordinates with [dogstatsd](https://github.com/DataDog/dogstatsd-csharp-client) via envvars.

### Motivation
Improve support for running multiple Azure Functions in the same hosting plan. [[jira](https://datadoghq.atlassian.net/browse/SVLS-8244)]

### Describe how to test/QA your changes
- [x] New unit tests
- [x] New self-monitoring: https://github.com/DataDog/serverless-compat-self-monitoring/pull/54